### PR TITLE
FIX: Intro Auth Python example should use official client, Settings keys should be listed

### DIFF
--- a/api/authentication.mdx
+++ b/api/authentication.mdx
@@ -83,34 +83,22 @@ https.get(url, {
 ```
 
 </TabItem>
+
 <TabItem value="Python" label="Python">
 
 ```python
-import requests
+from marketdata.client import MarketDataClient
 
-# Your token
-token = 'your_token_here'
+# Initialize the client (token is read from MARKETDATA_TOKEN environment variable)
+# Or pass it directly: client = MarketDataClient(token="your_token_here")
+client = MarketDataClient()
 
-# The API endpoint for retrieving stock quotes for SPY
-url = 'https://api.marketdata.app/v1/stocks/quotes/SPY/'
-
-# Setting up the headers for authentication
-headers = {
-    'Accept': 'application/json',
-    'Authorization': f'Bearer {token}'
-}
-
-# Making the GET request to the API
-response = requests.get(url, headers=headers)
-
-# Checking if the request was successful
-if response. status_code in (200, 203):
-    # Parsing the JSON response
-    data = response.json()
-    print(data)
-else:
-    print(f'Failed to retrieve data: {response.status_code}')
+# Get stock quotes for SPY
+quotes = client.stocks.quotes("SPY")
+print(quotes)
 ```
+
+For more information about using the Python SDK, see our [Python SDK documentation](/sdk/python) and [authentication guide](/sdk/python/authentication).
 
 </TabItem>
 

--- a/api/sdk.mdx
+++ b/api/sdk.mdx
@@ -14,9 +14,9 @@ We offer SDKs for various programming languages and platforms to cater to a wide
     [Comprehensive Postman Collection for easy API integration and testing.](/sdk/postman)
   </div>
   <div className="sdk-item">
-    ![Python SDK Logo](/img/python-logo-only.svg)
-    ### Python SDK
-    _In development_. Perfect for data analysis, backend services, and automation scripts.
+    [![Python SDK Logo](/img/python-logo-only.svg)](/sdk/python)
+    ### [Python SDK](/sdk/python)
+    [Perfect for data analysis, backend services, and automation scripts.](/sdk/python)
   </div>
   <div className="sdk-item">
     [![PHP SDK Logo](/img/php-logo.svg)](/sdk/php)

--- a/sdk/python/authentication.mdx
+++ b/sdk/python/authentication.mdx
@@ -11,9 +11,9 @@ The Market Data API uses a **Bearer Token** for authentication. The token is req
 There are two ways to set your token when using the Python SDK:
 
 1. Set it from an environment variable _(recommended)_
-2. Pass it directly when creating the client
+2. Pass it directly when creating the [client](/sdk/python/client)
 
-On startup, the SDK will look for the environment variable. If found, it will use the token for all requests. If the environment variable is not found, you will need to pass the token when creating the client.
+On startup, the SDK will look for the environment variable. If found, it will use the token for all requests. If the environment variable is not found, you will need to pass the token when creating the [client](/sdk/python/client).
 
 :::tip
 When your code is running in a production environment, we recommend using an environment variable to ensure your token is not stored with your code. This is the most secure way to set your token.
@@ -108,7 +108,7 @@ from marketdata.exceptions import MarketDataClientErrorResult
 # No need to set a token here, the SDK will read it
 # from the environment variable automatically.
 
-# Initialize the client
+# Initialize the client (see client documentation for details)
 client = MarketDataClient()
 
 # Make a test request
@@ -153,5 +153,7 @@ else:
 
 ## Next Steps
 
-After successful authentication, you will be able to begin making requests to the Market Data API. We recommend reading the brief overview of how the client works, so you can get familiar with interacting with the SDK. The SDK includes methods for each endpoint that allow you to retrieve data. Use any of the endpoints in the SDK to make requests to the API.
+After successful authentication, you will be able to begin making requests to the Market Data API. We recommend reading the brief overview of how the [client](/sdk/python/client) works, so you can get familiar with interacting with the SDK. The SDK includes methods for each endpoint that allow you to retrieve data. Use any of the endpoints in the SDK to make requests to the API.
+
+You may also want to configure [Settings](/sdk/python/settings) to customize output format, date format, and other universal parameters.
 

--- a/sdk/python/client.mdx
+++ b/sdk/python/client.mdx
@@ -11,9 +11,10 @@ The Market Data Python Client includes functionality for making API requests, ha
 ### Get Started Quickly with the MarketDataClient
 
 1. Review the [documentation on authentication](/sdk/python/authentication) to learn how to set your API token.
-2. Create a `MarketDataClient` instance and use it to make requests to the Market Data API.
+2. Create a [`MarketDataClient`](#MarketDataClient) instance and use it to make requests to the Market Data API.
 3. Make a test request and review the console output. The SDK includes logging capabilities to help you debug requests.
-4. Check the rate limit in the client to keep track of your requests and how many requests you have remaining.
+4. Check the [rate limit](#RateLimits) in the client to keep track of your requests and how many requests you have remaining.
+5. Configure [Settings](/sdk/python/settings) to customize output format, date format, and other universal parameters.
 
 <a name="MarketDataClient"></a>
 ## MarketDataClient
@@ -24,23 +25,23 @@ class MarketDataClient:
         ...
 ```
 
-MarketDataClient is the main client class for interacting with the Market Data API. It provides access to all resources (stocks, options, funds, markets) and handles authentication, rate limiting, and request management.
+[MarketDataClient](#MarketDataClient) is the main client class for interacting with the Market Data API. It provides access to all resources (stocks, options, funds, markets) and handles authentication, rate limiting, and request management.
 
 #### Properties
 
-- `token` (str): The authentication token for API requests
-- `rate_limits` (UserRateLimits): Current rate limit information
+- `token` (str): The authentication token for API requests. See [authentication documentation](/sdk/python/authentication) for details.
+- `rate_limits` ([UserRateLimits](#RateLimits)): Current rate limit information
 - `base_url` (str): The base URL for API requests
 - `api_version` (str): The API version to use
 - `headers` (dict): HTTP headers including Authorization and User-Agent
-- `default_params` (UserUniversalAPIParams): Default universal parameters for API requests
+- `default_params` ([UserUniversalAPIParams](/sdk/python/settings)): Default universal parameters for API requests. See [Settings](/sdk/python/settings) for details on configuring these parameters.
 
 #### Resources
 
-- `stocks` (StocksResource): Access to stocks endpoints (prices, quotes, candles, earnings, news)
-- `options` (OptionsResource): Access to options endpoints (chain, expirations, strikes, quotes, lookup)
-- `funds` (FundsResource): Access to funds endpoints (candles)
-- `markets` (MarketsResource): Access to markets endpoints (status)
+- `stocks` ([StocksResource](/sdk/python/stocks)): Access to stocks endpoints (prices, quotes, candles, earnings, news)
+- `options` ([OptionsResource](/sdk/python/options)): Access to options endpoints (chain, expirations, strikes, quotes, lookup)
+- `funds` ([FundsResource](/sdk/python/funds)): Access to funds endpoints (candles)
+- `markets` ([MarketsResource](/sdk/python/markets)): Access to markets endpoints (status)
 
 #### Methods
 
@@ -63,9 +64,9 @@ Creates and configures a new MarketDataClient instance with default settings. Th
 
   The authentication token for API requests. If not provided, the SDK will attempt to read it from the `MARKETDATA_TOKEN` environment variable.
 
-- `logger` (Logger, optional)
+- `logger` (`logging.Logger`, optional)
 
-  A custom logger instance. If not provided, the SDK will use its default logger.
+  A custom logger instance from Python's `logging` module. If not provided, the SDK will use its default logger. You can create a custom logger using `marketdata.logger.get_logger()`.
 
 #### Returns
 
@@ -128,182 +129,7 @@ print(rate_limits)  # Shows: "Rate used X/Y, remaining: Z credits, next reset: I
 
 The `requests_reset` field is automatically converted to a `datetime.datetime` object for easier use.
 
-<a name="ConfigurationPriority"></a>
-## Configuration Priority
+## Configuration
 
-The SDK supports multiple ways to configure universal parameters (like `output_format`, `date_format`, `mode`, etc.). These configuration methods follow a priority hierarchy, where higher priority settings override lower priority ones.
-
-### Priority Order (Lowest to Highest)
-
-1. **Environment Variables** (Lowest Priority)
-   - Set via environment variables like `MARKETDATA_OUTPUT_FORMAT`, `MARKETDATA_DATE_FORMAT`, etc.
-   - Applied globally to all API calls unless overridden
-
-2. **Client Default Parameters** (`client.default_params`)
-   - Set via `client.default_params` property
-   - Applied to all API calls made with that client instance unless overridden
-
-3. **Direct Method Parameters** (Highest Priority)
-   - Passed directly as keyword arguments to resource methods
-   - Applied only to that specific API call
-
-### How It Works
-
-When making an API call, the SDK merges parameters in the following order:
-
-1. **Start with environment variables** (lowest priority)
-   - Parameters are read from environment variables like `MARKETDATA_OUTPUT_FORMAT`, `MARKETDATA_DATE_FORMAT`, etc.
-
-2. **Override with `client.default_params`** (medium priority)
-   - Parameters set via `client.default_params` override environment variables
-   - Example: `client.default_params.output_format = OutputFormat.JSON`
-
-3. **Override with direct method parameters** (highest priority)
-   - Parameters passed directly to resource methods override both environment variables and `client.default_params`
-   - Example: `client.stocks.prices("AAPL", output_format=OutputFormat.DATAFRAME)`
-
-### Examples
-
-<Tabs>
-<TabItem value="Environment Variables" label="Environment Variables">
-
-Set universal parameters via environment variables:
-
-```python
-import os
-os.environ["MARKETDATA_OUTPUT_FORMAT"] = "json"
-os.environ["MARKETDATA_DATE_FORMAT"] = "timestamp"
-
-from marketdata.client import MarketDataClient
-
-client = MarketDataClient()
-
-# All calls will use JSON format and timestamp date format
-# (unless overridden by client.default_params or method parameters)
-prices = client.stocks.prices("AAPL")
-# Uses: output_format=JSON, date_format=TIMESTAMP
-```
-
-</TabItem>
-
-<TabItem value="Client Default Params" label="Client Default Params">
-
-Set universal parameters via `client.default_params`:
-
-```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat, DateFormat
-
-client = MarketDataClient()
-
-# Set default parameters for this client instance
-client.default_params.output_format = OutputFormat.JSON
-client.default_params.date_format = DateFormat.TIMESTAMP
-
-# All calls will use JSON format and timestamp date format
-# (unless overridden by method parameters)
-prices = client.stocks.prices("AAPL")
-# Uses: output_format=JSON, date_format=TIMESTAMP
-
-quotes = client.stocks.quotes("AAPL")
-# Uses: output_format=JSON, date_format=TIMESTAMP
-```
-
-**Note:** `client.default_params` overrides environment variables.
-
-</TabItem>
-
-<TabItem value="Direct Method Parameters" label="Direct Method Parameters">
-
-Pass parameters directly to resource methods:
-
-```python
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat, DateFormat
-
-client = MarketDataClient()
-
-# Set default parameters
-client.default_params.output_format = OutputFormat.JSON
-client.default_params.date_format = DateFormat.TIMESTAMP
-
-# Direct method parameters override client.default_params
-prices = client.stocks.prices(
-    "AAPL",
-    output_format=OutputFormat.DATAFRAME,  # Overrides JSON
-    date_format=DateFormat.UNIX  # Overrides TIMESTAMP
-)
-# Uses: output_format=DATAFRAME, date_format=UNIX
-
-# This call still uses client.default_params
-quotes = client.stocks.quotes("AAPL")
-# Uses: output_format=JSON, date_format=TIMESTAMP
-```
-
-**Note:** Direct method parameters override both environment variables and `client.default_params`.
-
-</TabItem>
-
-<TabItem value="Complete Example" label="Complete Example">
-
-Here's a complete example showing all three configuration methods:
-
-```python
-import os
-from marketdata.client import MarketDataClient
-from marketdata.input_types.base import OutputFormat, DateFormat
-
-# 1. Set environment variables (lowest priority)
-os.environ["MARKETDATA_OUTPUT_FORMAT"] = "csv"
-os.environ["MARKETDATA_DATE_FORMAT"] = "spreadsheet"
-
-client = MarketDataClient()
-
-# 2. Override with client.default_params (medium priority)
-client.default_params.output_format = OutputFormat.JSON
-client.default_params.date_format = DateFormat.TIMESTAMP
-
-# Call 1: Uses client.default_params (JSON, TIMESTAMP)
-prices1 = client.stocks.prices("AAPL")
-# Result: JSON format, TIMESTAMP date format
-
-# Call 2: Override with direct parameters (highest priority)
-prices2 = client.stocks.prices(
-    "AAPL",
-    output_format=OutputFormat.DATAFRAME,  # Overrides JSON
-    date_format=DateFormat.UNIX  # Overrides TIMESTAMP
-)
-# Result: DATAFRAME format, UNIX date format
-
-# Call 3: Uses client.default_params again (JSON, TIMESTAMP)
-quotes = client.stocks.quotes("AAPL")
-# Result: JSON format, TIMESTAMP date format
-```
-
-**Summary:**
-- Environment variables: `CSV`, `SPREADSHEET` (lowest priority)
-- `client.default_params`: `JSON`, `TIMESTAMP` (overrides env vars)
-- Direct parameters: `DATAFRAME`, `UNIX` (overrides everything)
-
-</TabItem>
-</Tabs>
-
-### Available Environment Variables
-
-You can set the following environment variables to configure universal parameters:
-
-- `MARKETDATA_OUTPUT_FORMAT`: Output format (`dataframe`, `internal`, `json`, `csv`)
-- `MARKETDATA_DATE_FORMAT`: Date format (`timestamp`, `unix`, `spreadsheet`)
-- `MARKETDATA_COLUMNS`: Comma-separated list of columns to include
-- `MARKETDATA_ADD_HEADERS`: Whether to include headers (`true`, `false`)
-- `MARKETDATA_USE_HUMAN_READABLE`: Whether to use human-readable format (`true`, `false`)
-- `MARKETDATA_MODE`: Data feed mode (`live`, `cached`, `delayed`)
-
-### Best Practices
-
-- **Use environment variables** for global defaults that apply across your entire application
-- **Use `client.default_params`** when you want different defaults for different client instances
-- **Use direct method parameters** when you need to override defaults for specific API calls
-
-This flexible configuration system allows you to set sensible defaults while still having fine-grained control over individual API calls.
+The SDK supports flexible configuration of universal parameters through multiple methods. You can configure settings like output format, date format, data mode, and more. See the [Settings](/sdk/python/settings) documentation for complete details on all available configuration options and how to use them.
 

--- a/sdk/python/funds/candles.mdx
+++ b/sdk/python/funds/candles.mdx
@@ -69,29 +69,29 @@ Fetches historical candles (OHLC) data for a fund symbol. The `symbol` parameter
 
   Number of candles to return, counting backwards from the `to_date`.
 
-- `output_format` (OutputFormat, optional)
+- `output_format` ([OutputFormat](/sdk/python/settings#output-format), optional)
 
-  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`.
+  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`. See [Settings](/sdk/python/settings) for details.
 
-- `date_format` (DateFormat, optional)
+- `date_format` ([DateFormat](/sdk/python/settings#date-format), optional)
 
-  The date format to use in the response. Defaults to `DateFormat.UNIX`.
+  The date format to use in the response. Defaults to `DateFormat.UNIX`. See [Settings](/sdk/python/settings) for details.
 
-- `columns` (list[str], optional)
+- [`columns`](/sdk/python/settings#columns) (optional)
 
-  Specify which columns to include in the response.
+  Specify which columns to include in the response. See [Settings](/sdk/python/settings) for details.
 
-- `add_headers` (bool, optional)
+- [`add_headers`](/sdk/python/settings#headers) (optional)
 
-  Whether to include headers in the response.
+  Whether to include headers in the response. See [Settings](/sdk/python/settings) for details.
 
-- `use_human_readable` (bool, optional)
+- [`use_human_readable`](/sdk/python/settings#human-readable) (optional)
 
-  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`.
+  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`. See [Settings](/sdk/python/settings) for details.
 
-- `mode` (Mode, optional)
+- `mode` ([Mode](/sdk/python/settings#data-mode), optional)
 
-  The data feed mode to use.
+  The data feed mode to use. See [Settings](/sdk/python/settings) for details.
 
 - `filename` (str | Path, optional)
 

--- a/sdk/python/funds/index.mdx
+++ b/sdk/python/funds/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Funds
-slug: /funds
+slug: /python/funds
 sidebar_position: 30
 ---
 

--- a/sdk/python/index.mdx
+++ b/sdk/python/index.mdx
@@ -20,6 +20,15 @@ The best source for documentation on the SDK is right here. This documentation i
 
 This SDK is designed to help you get up and running with Market Data's APIs as quickly as possible, providing you with all the tools you need to access real-time stock and options prices, historical data, and much more.
 
+### Getting Started
+
+1. Start by reading the [authentication guide](/sdk/python/authentication) to learn how to set up your API token.
+2. Learn about the [client](/sdk/python/client) and how to make your first API requests.
+3. Configure [Settings](/sdk/python/settings) to customize output format, date format, and other universal parameters.
+4. Explore the available endpoints for [stocks](/sdk/python/stocks), [options](/sdk/python/options), [funds](/sdk/python/funds), and [markets](/sdk/python/markets).
+
+### Support
+
 - If you have any questions or need further assistance, please don't hesitate to open a ticket at our [helpdesk](https://www.marketdata.app/dashboard/). 
 - If you find a bug you may also [open an issue in our GitHub repository](https://github.com/MarketDataApp/sdk-python/issues). Please only open issues if you find a bug. Use our helpdesk for general questions or implementation assistance.
 

--- a/sdk/python/markets/index.mdx
+++ b/sdk/python/markets/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Markets
-slug: /markets
+slug: /python/markets
 sidebar_position: 40
 ---
 

--- a/sdk/python/markets/status.mdx
+++ b/sdk/python/markets/status.mdx
@@ -64,29 +64,29 @@ Fetches market status information for specified dates and countries. All paramet
 
   Filter by country code (e.g., "US", "CA", "GB").
 
-- `output_format` (OutputFormat, optional)
+- `output_format` ([OutputFormat](/sdk/python/settings#output-format), optional)
 
-  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`.
+  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`. See [Settings](/sdk/python/settings) for details.
 
-- `date_format` (DateFormat, optional)
+- `date_format` ([DateFormat](/sdk/python/settings#date-format), optional)
 
-  The date format to use in the response. Defaults to `DateFormat.UNIX`.
+  The date format to use in the response. Defaults to `DateFormat.UNIX`. See [Settings](/sdk/python/settings) for details.
 
-- `columns` (list[str], optional)
+- [`columns`](/sdk/python/settings#columns) (optional)
 
-  Specify which columns to include in the response.
+  Specify which columns to include in the response. See [Settings](/sdk/python/settings) for details.
 
-- `add_headers` (bool, optional)
+- [`add_headers`](/sdk/python/settings#headers) (optional)
 
-  Whether to include headers in the response.
+  Whether to include headers in the response. See [Settings](/sdk/python/settings) for details.
 
-- `use_human_readable` (bool, optional)
+- [`use_human_readable`](/sdk/python/settings#human-readable) (optional)
 
-  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`.
+  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`. See [Settings](/sdk/python/settings) for details.
 
-- `mode` (Mode, optional)
+- `mode` ([Mode](/sdk/python/settings#data-mode), optional)
 
-  The data feed mode to use.
+  The data feed mode to use. See [Settings](/sdk/python/settings) for details.
 
 - `filename` (str | Path, optional)
 

--- a/sdk/python/options/chain.mdx
+++ b/sdk/python/options/chain.mdx
@@ -174,29 +174,29 @@ Fetches the options chain for a given symbol with extensive filtering options. T
 
   Filter by specific year.
 
-- `output_format` (OutputFormat, optional)
+- `output_format` ([OutputFormat](/sdk/python/settings#output-format), optional)
 
-  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`.
+  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`. See [Settings](/sdk/python/settings) for details.
 
-- `date_format` (DateFormat, optional)
+- `date_format` ([DateFormat](/sdk/python/settings#date-format), optional)
 
-  The date format to use in the response. Defaults to `DateFormat.UNIX`.
+  The date format to use in the response. Defaults to `DateFormat.UNIX`. See [Settings](/sdk/python/settings) for details.
 
-- `columns` (list[str], optional)
+- [`columns`](/sdk/python/settings#columns) (optional)
 
-  Specify which columns to include in the response.
+  Specify which columns to include in the response. See [Settings](/sdk/python/settings) for details.
 
-- `add_headers` (bool, optional)
+- [`add_headers`](/sdk/python/settings#headers) (optional)
 
-  Whether to include headers in the response.
+  Whether to include headers in the response. See [Settings](/sdk/python/settings) for details.
 
-- `use_human_readable` (bool, optional)
+- [`use_human_readable`](/sdk/python/settings#human-readable) (optional)
 
-  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`.
+  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`. See [Settings](/sdk/python/settings) for details.
 
-- `mode` (Mode, optional)
+- `mode` ([Mode](/sdk/python/settings#data-mode), optional)
 
-  The data feed mode to use.
+  The data feed mode to use. See [Settings](/sdk/python/settings) for details.
 
 - `filename` (str | Path, optional)
 

--- a/sdk/python/options/expirations.mdx
+++ b/sdk/python/options/expirations.mdx
@@ -54,29 +54,29 @@ Fetches available expiration dates for a given symbol. The `symbol` parameter ca
 
   Historical date for the expiration dates.
 
-- `output_format` (OutputFormat, optional)
+- `output_format` ([OutputFormat](/sdk/python/settings#output-format), optional)
 
-  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`.
+  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`. See [Settings](/sdk/python/settings) for details.
 
-- `date_format` (DateFormat, optional)
+- `date_format` ([DateFormat](/sdk/python/settings#date-format), optional)
 
-  The date format to use in the response. Defaults to `DateFormat.UNIX`.
+  The date format to use in the response. Defaults to `DateFormat.UNIX`. See [Settings](/sdk/python/settings) for details.
 
-- `columns` (list[str], optional)
+- [`columns`](/sdk/python/settings#columns) (optional)
 
-  Specify which columns to include in the response.
+  Specify which columns to include in the response. See [Settings](/sdk/python/settings) for details.
 
-- `add_headers` (bool, optional)
+- [`add_headers`](/sdk/python/settings#headers) (optional)
 
-  Whether to include headers in the response.
+  Whether to include headers in the response. See [Settings](/sdk/python/settings) for details.
 
-- `use_human_readable` (bool, optional)
+- [`use_human_readable`](/sdk/python/settings#human-readable) (optional)
 
-  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`.
+  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`. See [Settings](/sdk/python/settings) for details.
 
-- `mode` (Mode, optional)
+- `mode` ([Mode](/sdk/python/settings#data-mode), optional)
 
-  The data feed mode to use.
+  The data feed mode to use. See [Settings](/sdk/python/settings) for details.
 
 - `filename` (str | Path, optional)
 

--- a/sdk/python/options/index.mdx
+++ b/sdk/python/options/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Options
-slug: /options
+slug: /python/options
 sidebar_position: 20
 ---
 

--- a/sdk/python/options/lookup.mdx
+++ b/sdk/python/options/lookup.mdx
@@ -44,29 +44,29 @@ Fetches option lookup data for a given lookup string. The lookup string should c
 
   The lookup string in the format "SYMBOL DD-MM-YYYY STRIKE SIDE" (e.g., "AAPL 20-12-2024 150.0 call").
 
-- `output_format` (OutputFormat, optional)
+- `output_format` ([OutputFormat](/sdk/python/settings#output-format), optional)
 
-  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`.
+  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`. See [Settings](/sdk/python/settings) for details.
 
-- `date_format` (DateFormat, optional)
+- `date_format` ([DateFormat](/sdk/python/settings#date-format), optional)
 
-  The date format to use in the response. Defaults to `DateFormat.UNIX`.
+  The date format to use in the response. Defaults to `DateFormat.UNIX`. See [Settings](/sdk/python/settings) for details.
 
-- `columns` (list[str], optional)
+- [`columns`](/sdk/python/settings#columns) (optional)
 
-  Specify which columns to include in the response.
+  Specify which columns to include in the response. See [Settings](/sdk/python/settings) for details.
 
-- `add_headers` (bool, optional)
+- [`add_headers`](/sdk/python/settings#headers) (optional)
 
-  Whether to include headers in the response.
+  Whether to include headers in the response. See [Settings](/sdk/python/settings) for details.
 
-- `use_human_readable` (bool, optional)
+- [`use_human_readable`](/sdk/python/settings#human-readable) (optional)
 
-  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`.
+  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`. See [Settings](/sdk/python/settings) for details.
 
-- `mode` (Mode, optional)
+- `mode` ([Mode](/sdk/python/settings#data-mode), optional)
 
-  The data feed mode to use.
+  The data feed mode to use. See [Settings](/sdk/python/settings) for details.
 
 - `filename` (str | Path, optional)
 

--- a/sdk/python/options/quotes.mdx
+++ b/sdk/python/options/quotes.mdx
@@ -44,29 +44,29 @@ Fetches option quotes for one or more option symbols. Note: `quotes()` takes opt
 
   A single option symbol string or a list of option symbol strings for which to fetch quotes.
 
-- `output_format` (OutputFormat, optional)
+- `output_format` ([OutputFormat](/sdk/python/settings#output-format), optional)
 
-  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`.
+  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`. See [Settings](/sdk/python/settings) for details.
 
-- `date_format` (DateFormat, optional)
+- `date_format` ([DateFormat](/sdk/python/settings#date-format), optional)
 
-  The date format to use in the response. Defaults to `DateFormat.UNIX`.
+  The date format to use in the response. Defaults to `DateFormat.UNIX`. See [Settings](/sdk/python/settings) for details.
 
-- `columns` (list[str], optional)
+- [`columns`](/sdk/python/settings#columns) (optional)
 
-  Specify which columns to include in the response.
+  Specify which columns to include in the response. See [Settings](/sdk/python/settings) for details.
 
-- `add_headers` (bool, optional)
+- [`add_headers`](/sdk/python/settings#headers) (optional)
 
-  Whether to include headers in the response.
+  Whether to include headers in the response. See [Settings](/sdk/python/settings) for details.
 
-- `use_human_readable` (bool, optional)
+- [`use_human_readable`](/sdk/python/settings#human-readable) (optional)
 
-  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`.
+  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`. See [Settings](/sdk/python/settings) for details.
 
-- `mode` (Mode, optional)
+- `mode` ([Mode](/sdk/python/settings#data-mode), optional)
 
-  The data feed mode to use.
+  The data feed mode to use. See [Settings](/sdk/python/settings) for details.
 
 - `filename` (str | Path, optional)
 

--- a/sdk/python/options/strikes.mdx
+++ b/sdk/python/options/strikes.mdx
@@ -54,29 +54,29 @@ Fetches available strike prices for a given symbol. The `symbol` parameter can b
 
   Historical date for the strike prices.
 
-- `output_format` (OutputFormat, optional)
+- `output_format` ([OutputFormat](/sdk/python/settings#output-format), optional)
 
-  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`.
+  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`. See [Settings](/sdk/python/settings) for details.
 
-- `date_format` (DateFormat, optional)
+- `date_format` ([DateFormat](/sdk/python/settings#date-format), optional)
 
-  The date format to use in the response. Defaults to `DateFormat.UNIX`.
+  The date format to use in the response. Defaults to `DateFormat.UNIX`. See [Settings](/sdk/python/settings) for details.
 
-- `columns` (list[str], optional)
+- [`columns`](/sdk/python/settings#columns) (optional)
 
-  Specify which columns to include in the response.
+  Specify which columns to include in the response. See [Settings](/sdk/python/settings) for details.
 
-- `add_headers` (bool, optional)
+- [`add_headers`](/sdk/python/settings#headers) (optional)
 
-  Whether to include headers in the response.
+  Whether to include headers in the response. See [Settings](/sdk/python/settings) for details.
 
-- `use_human_readable` (bool, optional)
+- [`use_human_readable`](/sdk/python/settings#human-readable) (optional)
 
-  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`.
+  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`. See [Settings](/sdk/python/settings) for details.
 
-- `mode` (Mode, optional)
+- `mode` ([Mode](/sdk/python/settings#data-mode), optional)
 
-  The data feed mode to use.
+  The data feed mode to use. See [Settings](/sdk/python/settings) for details.
 
 - `filename` (str | Path, optional)
 

--- a/sdk/python/settings.mdx
+++ b/sdk/python/settings.mdx
@@ -1,0 +1,361 @@
+---
+title: Settings
+sidebar_position: 3
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+The Market Data Python SDK provides flexible configuration options for customizing API requests. You can configure universal parameters like output format, date format, data mode, and more through multiple methods with different priority levels.
+
+## Configuration Priority
+
+The SDK supports multiple ways to configure universal parameters. These configuration methods follow a priority hierarchy, where higher priority settings override lower priority ones.
+
+### Priority Order (Lowest to Highest)
+
+1. **Environment Variables** (Lowest Priority)
+   - Set via environment variables like `MARKETDATA_OUTPUT_FORMAT`, `MARKETDATA_DATE_FORMAT`, etc.
+   - Applied globally to all API calls unless overridden
+
+2. **Client Default Parameters** (`client.default_params`)
+   - Set via `client.default_params` property
+   - Applied to all API calls made with that client instance unless overridden
+
+3. **Direct Method Parameters** (Highest Priority)
+   - Passed directly as keyword arguments to resource methods
+   - Applied only to that specific API call
+
+### How It Works
+
+When making an API call, the SDK merges parameters in the following order:
+
+1. **Start with environment variables** (lowest priority)
+   - Parameters are read from environment variables like `MARKETDATA_OUTPUT_FORMAT`, `MARKETDATA_DATE_FORMAT`, etc.
+
+2. **Override with `client.default_params`** (medium priority)
+   - Parameters set via `client.default_params` override environment variables
+   - Example: `client.default_params.output_format = OutputFormat.JSON`
+
+3. **Override with direct method parameters** (highest priority)
+   - Parameters passed directly to resource methods override both environment variables and `client.default_params`
+   - Example: `client.stocks.prices("AAPL", output_format=OutputFormat.DATAFRAME)`
+
+### Examples
+
+<Tabs>
+<TabItem value="Environment Variables" label="Environment Variables">
+
+Set universal parameters via environment variables:
+
+```python
+import os
+os.environ["MARKETDATA_OUTPUT_FORMAT"] = "json"
+os.environ["MARKETDATA_DATE_FORMAT"] = "timestamp"
+
+from marketdata.client import MarketDataClient
+
+client = MarketDataClient()
+
+# All calls will use JSON format and timestamp date format
+# (unless overridden by client.default_params or method parameters)
+prices = client.stocks.prices("AAPL")
+# Uses: output_format=JSON, date_format=TIMESTAMP
+```
+
+</TabItem>
+
+<TabItem value="Client Default Params" label="Client Default Params">
+
+Set universal parameters via `client.default_params`:
+
+```python
+from marketdata.client import MarketDataClient
+from marketdata.input_types.base import OutputFormat, DateFormat
+
+client = MarketDataClient()
+
+# Set default parameters for this client instance
+client.default_params.output_format = OutputFormat.JSON
+client.default_params.date_format = DateFormat.TIMESTAMP
+
+# All calls will use JSON format and timestamp date format
+# (unless overridden by method parameters)
+prices = client.stocks.prices("AAPL")
+# Uses: output_format=JSON, date_format=TIMESTAMP
+
+quotes = client.stocks.quotes("AAPL")
+# Uses: output_format=JSON, date_format=TIMESTAMP
+```
+
+**Note:** `client.default_params` overrides environment variables.
+
+</TabItem>
+
+<TabItem value="Direct Method Parameters" label="Direct Method Parameters">
+
+Pass parameters directly to resource methods:
+
+```python
+from marketdata.client import MarketDataClient
+from marketdata.input_types.base import OutputFormat, DateFormat
+
+client = MarketDataClient()
+
+# Set default parameters
+client.default_params.output_format = OutputFormat.JSON
+client.default_params.date_format = DateFormat.TIMESTAMP
+
+# Direct method parameters override client.default_params
+prices = client.stocks.prices(
+    "AAPL",
+    output_format=OutputFormat.DATAFRAME,  # Overrides JSON
+    date_format=DateFormat.UNIX  # Overrides TIMESTAMP
+)
+# Uses: output_format=DATAFRAME, date_format=UNIX
+
+# This call still uses client.default_params
+quotes = client.stocks.quotes("AAPL")
+# Uses: output_format=JSON, date_format=TIMESTAMP
+```
+
+**Note:** Direct method parameters override both environment variables and `client.default_params`.
+
+</TabItem>
+</Tabs>
+
+## Available Configuration Options
+
+### Output Format
+
+Controls the format of the API response data.
+
+**Available Values:**
+- `OutputFormat.DATAFRAME` (default): Returns data as a pandas DataFrame
+- `OutputFormat.JSON`: Returns data as JSON
+- `OutputFormat.CSV`: Returns data as CSV (saves to file)
+- `OutputFormat.INTERNAL`: Returns data in internal format
+
+**Configuration Methods:**
+
+1. **Environment Variable:** `MARKETDATA_OUTPUT_FORMAT` (values: `dataframe`, `internal`, `json`, `csv`)
+2. **Client Default:** `client.default_params.output_format = OutputFormat.JSON`
+3. **Direct Parameter:** `client.stocks.quotes("AAPL", output_format=OutputFormat.JSON)`
+
+**Example:**
+```python
+from marketdata.client import MarketDataClient
+from marketdata.input_types.base import OutputFormat
+
+client = MarketDataClient()
+
+# Method 1: Environment variable
+# export MARKETDATA_OUTPUT_FORMAT=json
+
+# Method 2: Client default params
+client.default_params.output_format = OutputFormat.JSON
+
+# Method 3: Direct parameter (highest priority)
+quotes = client.stocks.quotes("AAPL", output_format=OutputFormat.DATAFRAME)
+```
+
+For more details, see the [API Format documentation](/api/universal-parameters/format).
+
+### Date Format
+
+Specifies the format for date and time information in responses.
+
+**Available Values:**
+- `DateFormat.TIMESTAMP`: ISO 8601 timestamp format (e.g., `2020-12-30 16:00:00 -05:00`)
+- `DateFormat.UNIX`: Unix timestamp in seconds (e.g., `1609362000`)
+- `DateFormat.SPREADSHEET`: Excel spreadsheet format (e.g., `44195.66667`)
+
+**Configuration Methods:**
+
+1. **Environment Variable:** `MARKETDATA_DATE_FORMAT` (values: `timestamp`, `unix`, `spreadsheet`)
+2. **Client Default:** `client.default_params.date_format = DateFormat.UNIX`
+3. **Direct Parameter:** `client.stocks.candles("AAPL", date_format=DateFormat.UNIX)`
+
+**Example:**
+```python
+from marketdata.client import MarketDataClient
+from marketdata.input_types.base import DateFormat
+
+client = MarketDataClient()
+
+# Method 1: Environment variable
+# export MARKETDATA_DATE_FORMAT=unix
+
+# Method 2: Client default params
+client.default_params.date_format = DateFormat.UNIX
+
+# Method 3: Direct parameter (highest priority)
+candles = client.stocks.candles("AAPL", date_format=DateFormat.TIMESTAMP)
+```
+
+For more details, see the [API Date Format documentation](/api/universal-parameters/date-format).
+
+### Columns
+
+Limits the response to only the columns you need, reducing data transfer and processing time.
+
+**Type:** `list[str]` or comma-separated string
+
+**Configuration Methods:**
+
+1. **Environment Variable:** `MARKETDATA_COLUMNS` (comma-separated list, e.g., `ask,bid`)
+2. **Client Default:** `client.default_params.columns = ["ask", "bid"]`
+3. **Direct Parameter:** `client.stocks.quotes("AAPL", columns=["ask", "bid"])`
+
+**Example:**
+```python
+from marketdata.client import MarketDataClient
+
+client = MarketDataClient()
+
+# Method 1: Environment variable
+# export MARKETDATA_COLUMNS=ask,bid
+
+# Method 2: Client default params
+client.default_params.columns = ["ask", "bid"]
+
+# Method 3: Direct parameter (highest priority)
+quotes = client.stocks.quotes("AAPL", columns=["ask", "bid"])
+# Or as a comma-separated string
+quotes = client.stocks.quotes("AAPL", columns="ask,bid")
+```
+
+For more details, see the [API Columns documentation](/api/universal-parameters/columns).
+
+### Headers
+
+Controls whether headers are included in CSV output.
+
+**Type:** `bool`
+
+**Default:** `True`
+
+**Configuration Methods:**
+
+1. **Environment Variable:** `MARKETDATA_ADD_HEADERS` (values: `true`, `false`)
+2. **Client Default:** `client.default_params.add_headers = False`
+3. **Direct Parameter:** `client.stocks.candles("AAPL", add_headers=False)`
+
+**Example:**
+```python
+from marketdata.client import MarketDataClient
+from marketdata.input_types.base import OutputFormat
+
+client = MarketDataClient()
+
+# Method 1: Environment variable
+# export MARKETDATA_ADD_HEADERS=false
+
+# Method 2: Client default params
+client.default_params.add_headers = False
+
+# Method 3: Direct parameter (highest priority)
+candles = client.stocks.candles(
+    "AAPL",
+    output_format=OutputFormat.CSV,
+    add_headers=False
+)
+```
+
+For more details, see the [API Headers documentation](/api/universal-parameters/headers).
+
+### Human Readable
+
+Uses human-readable attribute names in JSON or CSV output instead of camelCase. Only applies when `output_format=OutputFormat.INTERNAL`.
+
+**Type:** `bool`
+
+**Default:** `False`
+
+**Configuration Methods:**
+
+1. **Environment Variable:** `MARKETDATA_USE_HUMAN_READABLE` (values: `true`, `false`)
+2. **Client Default:** `client.default_params.use_human_readable = True`
+3. **Direct Parameter:** `client.stocks.quotes("AAPL", use_human_readable=True)`
+
+**Example:**
+```python
+from marketdata.client import MarketDataClient
+from marketdata.input_types.base import OutputFormat
+
+client = MarketDataClient()
+
+# Method 1: Environment variable
+# export MARKETDATA_USE_HUMAN_READABLE=true
+
+# Method 2: Client default params
+client.default_params.use_human_readable = True
+
+# Method 3: Direct parameter (highest priority)
+quotes = client.stocks.quotes(
+    "AAPL",
+    output_format=OutputFormat.INTERNAL,
+    use_human_readable=True
+)
+```
+
+For more details, see the [API Human Readable documentation](/api/universal-parameters/human-readable).
+
+### Data Mode
+
+Controls how an API request is fulfilled, including data freshness guarantees and credit usage.
+
+**Available Values:**
+- `Mode.LIVE`: Real-time data (default for paid accounts)
+- `Mode.CACHED`: Recently cached data (reduces credit usage for bulk quotes)
+- `Mode.DELAYED`: Data delayed by at least 15 minutes (default for free/trial accounts)
+
+**Configuration Methods:**
+
+1. **Environment Variable:** `MARKETDATA_MODE` (values: `live`, `cached`, `delayed`)
+2. **Client Default:** `client.default_params.mode = Mode.CACHED`
+3. **Direct Parameter:** `client.options.chain("SPY", mode=Mode.CACHED)`
+
+**Example:**
+```python
+from marketdata.client import MarketDataClient
+from marketdata.input_types.base import Mode
+
+client = MarketDataClient()
+
+# Method 1: Environment variable
+# export MARKETDATA_MODE=cached
+
+# Method 2: Client default params
+client.default_params.mode = Mode.CACHED
+
+# Method 3: Direct parameter (highest priority)
+chain = client.options.chain("SPY", mode=Mode.CACHED)
+quotes = client.stocks.quotes("AAPL", mode=Mode.LIVE)
+```
+
+:::info Premium Parameter
+The `mode` parameter is available only on paid plans. Free and trial plans cannot change the data mode and will always receive delayed data.
+:::
+
+For more details, see the [API Mode documentation](/api/universal-parameters/mode).
+
+## Available Environment Variables
+
+You can set the following environment variables to configure universal parameters globally:
+
+- `MARKETDATA_OUTPUT_FORMAT`: Output format (`dataframe`, `internal`, `json`, `csv`)
+- `MARKETDATA_DATE_FORMAT`: Date format (`timestamp`, `unix`, `spreadsheet`)
+- `MARKETDATA_COLUMNS`: Comma-separated list of columns to include
+- `MARKETDATA_ADD_HEADERS`: Whether to include headers (`true`, `false`)
+- `MARKETDATA_USE_HUMAN_READABLE`: Whether to use human-readable format (`true`, `false`)
+- `MARKETDATA_MODE`: Data feed mode (`live`, `cached`, `delayed`)
+
+## Best Practices
+
+- **Use environment variables** for global defaults that apply across your entire application
+- **Use `client.default_params`** when you want different defaults for different client instances
+- **Use direct method parameters** when you need to override defaults for specific API calls
+
+This flexible configuration system allows you to set sensible defaults while still having fine-grained control over individual API calls.
+

--- a/sdk/python/stocks/candles.mdx
+++ b/sdk/python/stocks/candles.mdx
@@ -84,29 +84,29 @@ Fetches historical candles (OHLCV) data for a stock symbol. Supports various tim
 
   Filter by exchange.
 
-- `output_format` (OutputFormat, optional)
+- `output_format` ([OutputFormat](/sdk/python/settings#output-format), optional)
 
-  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`.
+  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`. See [Settings](/sdk/python/settings) for details.
 
-- `date_format` (DateFormat, optional)
+- `date_format` ([DateFormat](/sdk/python/settings#date-format), optional)
 
-  The date format to use in the response. Defaults to `DateFormat.UNIX`.
+  The date format to use in the response. Defaults to `DateFormat.UNIX`. See [Settings](/sdk/python/settings) for details.
 
-- `columns` (list[str], optional)
+- [`columns`](/sdk/python/settings#columns) (optional)
 
-  Specify which columns to include in the response.
+  Specify which columns to include in the response. See [Settings](/sdk/python/settings) for details.
 
-- `add_headers` (bool, optional)
+- [`add_headers`](/sdk/python/settings#headers) (optional)
 
-  Whether to include headers in the response.
+  Whether to include headers in the response. See [Settings](/sdk/python/settings) for details.
 
-- `use_human_readable` (bool, optional)
+- [`use_human_readable`](/sdk/python/settings#human-readable) (optional)
 
-  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`.
+  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`. See [Settings](/sdk/python/settings) for details.
 
-- `mode` (Mode, optional)
+- `mode` ([Mode](/sdk/python/settings#data-mode), optional)
 
-  The data feed mode to use.
+  The data feed mode to use. See [Settings](/sdk/python/settings) for details.
 
 - `filename` (str | Path, optional)
 

--- a/sdk/python/stocks/earnings.mdx
+++ b/sdk/python/stocks/earnings.mdx
@@ -69,29 +69,29 @@ Fetches earnings data for a stock symbol. The `symbol` parameter can be passed a
 
   Number of earnings reports to return, counting backwards from the `to_date`.
 
-- `output_format` (OutputFormat, optional)
+- `output_format` ([OutputFormat](/sdk/python/settings#output-format), optional)
 
-  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`.
+  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`. See [Settings](/sdk/python/settings) for details.
 
-- `date_format` (DateFormat, optional)
+- `date_format` ([DateFormat](/sdk/python/settings#date-format), optional)
 
-  The date format to use in the response. Defaults to `DateFormat.UNIX`.
+  The date format to use in the response. Defaults to `DateFormat.UNIX`. See [Settings](/sdk/python/settings) for details.
 
-- `columns` (list[str], optional)
+- [`columns`](/sdk/python/settings#columns) (optional)
 
-  Specify which columns to include in the response.
+  Specify which columns to include in the response. See [Settings](/sdk/python/settings) for details.
 
-- `add_headers` (bool, optional)
+- [`add_headers`](/sdk/python/settings#headers) (optional)
 
-  Whether to include headers in the response.
+  Whether to include headers in the response. See [Settings](/sdk/python/settings) for details.
 
-- `use_human_readable` (bool, optional)
+- [`use_human_readable`](/sdk/python/settings#human-readable) (optional)
 
-  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`.
+  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`. See [Settings](/sdk/python/settings) for details.
 
-- `mode` (Mode, optional)
+- `mode` ([Mode](/sdk/python/settings#data-mode), optional)
 
-  The data feed mode to use.
+  The data feed mode to use. See [Settings](/sdk/python/settings) for details.
 
 - `filename` (str | Path, optional)
 

--- a/sdk/python/stocks/index.mdx
+++ b/sdk/python/stocks/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Stocks
-slug: /stocks
+slug: /python/stocks
 sidebar_position: 10
 ---
 

--- a/sdk/python/stocks/news.mdx
+++ b/sdk/python/stocks/news.mdx
@@ -64,29 +64,29 @@ Fetches news articles for a stock symbol. The `symbol` parameter can be passed a
 
   Number of news articles to return, counting backwards from the `to_date`.
 
-- `output_format` (OutputFormat, optional)
+- `output_format` ([OutputFormat](/sdk/python/settings#output-format), optional)
 
-  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`.
+  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`. See [Settings](/sdk/python/settings) for details.
 
-- `date_format` (DateFormat, optional)
+- `date_format` ([DateFormat](/sdk/python/settings#date-format), optional)
 
-  The date format to use in the response. Defaults to `DateFormat.UNIX`.
+  The date format to use in the response. Defaults to `DateFormat.UNIX`. See [Settings](/sdk/python/settings) for details.
 
-- `columns` (list[str], optional)
+- [`columns`](/sdk/python/settings#columns) (optional)
 
-  Specify which columns to include in the response.
+  Specify which columns to include in the response. See [Settings](/sdk/python/settings) for details.
 
-- `add_headers` (bool, optional)
+- [`add_headers`](/sdk/python/settings#headers) (optional)
 
-  Whether to include headers in the response.
+  Whether to include headers in the response. See [Settings](/sdk/python/settings) for details.
 
-- `use_human_readable` (bool, optional)
+- [`use_human_readable`](/sdk/python/settings#human-readable) (optional)
 
-  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`.
+  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`. See [Settings](/sdk/python/settings) for details.
 
-- `mode` (Mode, optional)
+- `mode` ([Mode](/sdk/python/settings#data-mode), optional)
 
-  The data feed mode to use.
+  The data feed mode to use. See [Settings](/sdk/python/settings) for details.
 
 - `filename` (str | Path, optional)
 

--- a/sdk/python/stocks/prices.mdx
+++ b/sdk/python/stocks/prices.mdx
@@ -44,29 +44,29 @@ Fetches stock prices for one or more symbols. The `symbols` parameter can be pas
 
   A single symbol string or a list of symbol strings for which to fetch prices.
 
-- `output_format` (OutputFormat, optional)
+- `output_format` ([OutputFormat](/sdk/python/settings#output-format), optional)
 
-  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`.
+  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`. See [Settings](/sdk/python/settings) for details.
 
-- `date_format` (DateFormat, optional)
+- `date_format` ([DateFormat](/sdk/python/settings#date-format), optional)
 
-  The date format to use in the response. Defaults to `DateFormat.UNIX`.
+  The date format to use in the response. Defaults to `DateFormat.UNIX`. See [Settings](/sdk/python/settings) for details.
 
-- `columns` (list[str], optional)
+- [`columns`](/sdk/python/settings#columns) (optional)
 
-  Specify which columns to include in the response.
+  Specify which columns to include in the response. See [Settings](/sdk/python/settings) for details.
 
-- `add_headers` (bool, optional)
+- [`add_headers`](/sdk/python/settings#headers) (optional)
 
-  Whether to include headers in the response.
+  Whether to include headers in the response. See [Settings](/sdk/python/settings) for details.
 
-- `use_human_readable` (bool, optional)
+- [`use_human_readable`](/sdk/python/settings#human-readable) (optional)
 
-  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`.
+  Whether to use human-readable format for values. Only applies when `output_format=OutputFormat.INTERNAL`. See [Settings](/sdk/python/settings) for details.
 
-- `mode` (Mode, optional)
+- `mode` ([Mode](/sdk/python/settings#data-mode), optional)
 
-  The data feed mode to use.
+  The data feed mode to use. See [Settings](/sdk/python/settings) for details.
 
 - `filename` (str | Path, optional)
 

--- a/sdk/python/stocks/quotes.mdx
+++ b/sdk/python/stocks/quotes.mdx
@@ -54,29 +54,29 @@ Fetches stock quotes for one or more symbols. The `symbols` parameter can be pas
 
   Whether to use the extended quotes.
 
-- `output_format` (OutputFormat, optional)
+- `output_format` ([OutputFormat](/sdk/python/settings#output-format), optional)
 
-  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`.
+  The format of the returned data. Defaults to `OutputFormat.DATAFRAME`. See [Settings](/sdk/python/settings) for details.
 
-- `date_format` (DateFormat, optional)
+- `date_format` ([DateFormat](/sdk/python/settings#date-format), optional)
 
-  The date format to use in the response. Defaults to `DateFormat.UNIX`.
+  The date format to use in the response. Defaults to `DateFormat.UNIX`. See [Settings](/sdk/python/settings) for details.
 
-- `columns` (list[str], optional)
+- [`columns`](/sdk/python/settings#columns) (optional)
 
-  Specify which columns to include in the response. If not provided, all available columns are returned.
+  Specify which columns to include in the response. If not provided, all available columns are returned. See [Settings](/sdk/python/settings) for details.
 
-- `add_headers` (bool, optional)
+- [`add_headers`](/sdk/python/settings#headers) (optional)
 
-  Whether to include headers in the response. Uses API alias `headers`.
+  Whether to include headers in the response. Uses API alias `headers`. See [Settings](/sdk/python/settings) for details.
 
-- `use_human_readable` (bool, optional)
+- [`use_human_readable`](/sdk/python/settings#human-readable) (optional)
 
-  Whether to use human-readable format for values. Uses API alias `human`. Only applies when `output_format=OutputFormat.INTERNAL`.
+  Whether to use human-readable format for values. Uses API alias `human`. Only applies when `output_format=OutputFormat.INTERNAL`. See [Settings](/sdk/python/settings) for details.
 
-- `mode` (Mode, optional)
+- `mode` ([Mode](/sdk/python/settings#data-mode), optional)
 
-  The data feed mode to use. Available options: `Mode.LIVE`, `Mode.CACHED`, `Mode.DELAYED`.
+  The data feed mode to use. Available options: `Mode.LIVE`, `Mode.CACHED`, `Mode.DELAYED`. See [Settings](/sdk/python/settings) for details.
 
 - `filename` (str | Path, optional)
 


### PR DESCRIPTION
…eys should be listed