### PR TITLE
Graceful Context7 chat widget transitions

### DIFF
--- a/src/components/Context7Widget.js
+++ b/src/components/Context7Widget.js
@@ -109,6 +109,44 @@ function isChatEngaged() {
   return panelOpen && hasUserMessages;
 }
 
+/** Returns true when the chat panel is currently open. */
+function isPanelOpen() {
+  const container = document.getElementById('context7-widget');
+  const sr = container?.shadowRoot;
+  if (!sr) return false;
+  return sr.querySelector('.c7-panel')?.classList.contains('open') ?? false;
+}
+
+/**
+ * Watch for the chat panel to open for the first time.
+ * Calls `callback` once when that happens, then auto-disconnects.
+ * Returns a cleanup function to cancel the observer early.
+ */
+function observePanelOpen(callback) {
+  const container = document.getElementById('context7-widget');
+  const sr = container?.shadowRoot;
+  if (!sr) return () => {};
+
+  const panel = sr.querySelector('.c7-panel');
+  if (!panel) return () => {};
+
+  // Already open.
+  if (panel.classList.contains('open')) {
+    callback();
+    return () => {};
+  }
+
+  const observer = new MutationObserver(() => {
+    if (panel.classList.contains('open')) {
+      observer.disconnect();
+      callback();
+    }
+  });
+
+  observer.observe(panel, {attributes: true, attributeFilter: ['class']});
+  return () => observer.disconnect();
+}
+
 /**
  * Watch for the chat panel to close (`.c7-panel` loses the `open` class).
  * Calls `callback` once when that happens, then auto-disconnects.
@@ -170,8 +208,12 @@ export default function Context7Widget() {
   const panelCleanupRef = useRef(null);
   // Cleanup fn for the theme observer.
   const themeCleanupRef = useRef(null);
+  // Cleanup fn for the panel-open observer (tracks first open).
+  const openObserverCleanupRef = useRef(null);
   // The last color injected (so we can do in-place replacement on theme change).
   const lastColorRef = useRef(null);
+  // Whether the user has ever opened the chat panel for the current widget.
+  const hasOpenedRef = useRef(false);
 
   function cancelPanelObserver() {
     if (panelCleanupRef.current) {
@@ -187,14 +229,39 @@ export default function Context7Widget() {
     }
   }
 
+  function cancelOpenObserver() {
+    if (openObserverCleanupRef.current) {
+      openObserverCleanupRef.current();
+      openObserverCleanupRef.current = null;
+    }
+  }
+
   function performSwitch(widget) {
     cancelPanelObserver();
     cancelThemeObserver();
+    cancelOpenObserver();
     pendingRef.current = null;
+    hasOpenedRef.current = false;
 
     injectWidget(widget);
     activeRef.current = widget;
     lastColorRef.current = getThemeColor();
+
+    // Watch for the user to open the chat panel for the first time.
+    // The widget script loads async, so poll briefly until the shadow DOM is ready.
+    let attempts = 0;
+    const tryObserve = () => {
+      const container = document.getElementById('context7-widget');
+      if (container?.shadowRoot?.querySelector('.c7-panel')) {
+        openObserverCleanupRef.current = observePanelOpen(() => {
+          hasOpenedRef.current = true;
+        });
+      } else if (attempts < 20) {
+        attempts++;
+        setTimeout(tryObserve, 250);
+      }
+    };
+    tryObserve();
 
     // Watch for theme changes — update color in-place instead of re-injecting.
     const themeObserver = new MutationObserver(() => {
@@ -224,10 +291,20 @@ export default function Context7Widget() {
       return;
     }
 
-    // Navigated to a page with no widget: keep current widget open (sticky).
+    // Navigated to a page with no widget.
     if (targetWidget === null) {
-      pendingRef.current = null;
-      cancelPanelObserver();
+      if (hasOpenedRef.current) {
+        // User has interacted with the chat — keep it open (sticky).
+        pendingRef.current = null;
+        cancelPanelObserver();
+      } else {
+        // User never opened the chat — clean up so the bubble doesn't linger.
+        cancelPanelObserver();
+        cancelThemeObserver();
+        cancelOpenObserver();
+        cleanupWidget();
+        activeRef.current = null;
+      }
       return;
     }
 
@@ -260,10 +337,12 @@ export default function Context7Widget() {
     return () => {
       cancelPanelObserver();
       cancelThemeObserver();
+      cancelOpenObserver();
       uninstallShadowPatch();
       cleanupWidget();
       activeRef.current = null;
       pendingRef.current = null;
+      hasOpenedRef.current = false;
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- **Sticky widget**: Chat bubble stays on non-widget pages (e.g. `/account/`) only if the user has opened it at least once. If never interacted with, the bubble is cleaned up.
- **Deferred switching**: When navigating between SDK sections (e.g. Python → PHP) while the user has an active conversation (panel open + messages sent), the switch is deferred until the user closes the chat panel.
- **Immediate switching**: When the chat panel is closed or the user hasn't sent any messages, switching between SDK sections happens instantly.
- **Theme fix**: Dark/light mode toggle now updates widget colors in-place via shadow DOM style rewriting instead of destroying and recreating the entire widget (which previously lost conversations).

## Test plan
- [ ] Navigate to `/sdk/py/` → widget loads
- [ ] Navigate to `/account/` without opening chat → bubble disappears
- [ ] Navigate to `/sdk/py/`, open chat, close it, navigate to `/account/` → bubble stays (sticky)
- [ ] Navigate to `/sdk/php/` with panel closed → immediate switch to PHP
- [ ] Open chat on `/sdk/py/`, type a message, navigate to `/sdk/php/` → chat stays open with Python context
- [ ] Close the chat panel → silently switches to PHP widget
- [ ] Toggle dark/light mode while chatting → color changes without destroying conversation

🤖 Generated with [Claude Code](https://claude.com/claude-code)