### PR TITLE
fix: 404 logging and feed → mode redirect

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -50,6 +50,7 @@ jobs:
           mkdir -p "build/${BASE_URL}"
           mv build-raw/* "build/${BASE_URL}/"
           rm -rf build-raw
+          cp "build/${BASE_URL}/404.html" build/404.html
 
       - name: Generate cache headers
         env:

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -76,6 +76,10 @@ const config = {
             from: "/sheets/troubleshooting/common-error-messages",
             to: "/sheets/troubleshooting",
           },
+          {
+            from: "/api/universal-parameters/feed",
+            to: "/api/universal-parameters/mode",
+          },
         ],
       },
     ],

--- a/worker/index.js
+++ b/worker/index.js
@@ -64,7 +64,15 @@ async function handleRequest(request) {
   for (const route of ROUTES) {
     if (matchesRoute(url.pathname, route.prefix)) {
       url.hostname = route.target;
-      return fetch(new Request(url, request), { cf: { cacheEverything: true } });
+      const response = await fetch(new Request(url, request), { cf: { cacheEverything: true } });
+
+      if (response.status === 404) {
+        const pathname = new URL(request.url).pathname;
+        const referer = request.headers.get('referer');
+        console.log({ level: '404', message: pathname, referer: referer || '' });
+      }
+
+      return response;
     }
   }
 

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -8,3 +8,7 @@ routes = [
   { pattern = "www.marketdata.app/docs", zone_name = "marketdata.app" },
   { pattern = "www.marketdata.app/docs/*", zone_name = "marketdata.app" },
 ]
+
+[observability]
+enabled = true
+head_sampling_rate = 1


### PR DESCRIPTION
## Summary
- Enable Cloudflare Workers Logs observability with 100% sampling for 404 diagnostics
- Log 404 paths and referers to Workers Logs (filterable by `level = 404`)
- Copy `404.html` to build root in CI so Cloudflare Pages serves the custom 404 page
- Add client redirect from `/api/universal-parameters/feed` to `/api/universal-parameters/mode`

## Test plan
- [ ] Verify staging deploy succeeds
- [ ] Visit `www.marketdata.app/docs-staging/api/universal-parameters/feed` and confirm redirect to `/mode`
- [ ] Visit a fake URL and confirm custom 404 page loads
- [ ] Check Workers Logs in Cloudflare dashboard with `level = 404` filter