### PR TITLE
Add account troubleshooting section

### DIFF
--- a/account/data-policies/account-verification.md
+++ b/account/data-policies/account-verification.md
@@ -7,6 +7,10 @@ Market Data verifies the identity and employment information of all paid subscri
 
 See [Professional Status Policy](/docs/account/data-policies/professional-status/) for details on what the classifications mean and the consequences of misclassification.
 
+:::tip Having trouble with verification?
+If your account verification is delayed or you've been asked to provide additional documentation, see [Account Troubleshooting](/docs/account/troubleshooting/) for help with common issues.
+:::
+
 ## Information We Collect
 
 | Contact Information | Employer Information |

--- a/account/entitlements.md
+++ b/account/entitlements.md
@@ -10,9 +10,9 @@ For your obligations under these agreements, see [Exchange Agreements](/docs/acc
 ## Available Entitlements
 
 ### IEX Entitlement
-- **Data Type**: Real-time stock quotes and trades
+- **Data Type**: Stock quotes and trades
 - **Exchange**: Investors Exchange (IEX)
-- **Benefit**: Access to real-time stock data
+- **Benefit**: Access to stock quote and trade data
 - **Plan Requirement**: Any paid Market Data plan
 
 ### UTP Entitlement
@@ -22,9 +22,9 @@ For your obligations under these agreements, see [Exchange Agreements](/docs/acc
 - **Plan Requirement**: Any paid Market Data plan
 
 ### OPRA Entitlement
-- **Data Type**: Real-time options quotes and trades
+- **Data Type**: Options quotes and trades
 - **Exchange**: Options Price Reporting Authority (OPRA)
-- **Benefit**: Access to real-time options data
+- **Benefit**: Access to options data
 - **Plan Requirement**: Paid Trader plan or above
 
 ## How to Get Your Entitlement

--- a/account/troubleshooting/account-deletion.md
+++ b/account/troubleshooting/account-deletion.md
@@ -1,0 +1,49 @@
+---
+title: Account Deletion
+sidebar_position: 8
+---
+
+## Overview
+
+You can request the deletion of your Market Data account and all associated personal data at any time. Account deletion is permanent and cannot be undone.
+
+## How to Request Deletion
+
+Contact our [support helpdesk](https://www.marketdata.app/dashboard/) and request that your account and personal data be deleted. Please include the email address associated with your account.
+
+## What Happens Next
+
+1. Our support team will acknowledge your request and confirm the details.
+2. You will receive a confirmation email notifying you that your account and data have been deleted.
+3. Your account, profile information, and personal data will be permanently removed from our systems. If you have an active subscription, access ends immediately.
+
+Once deletion is complete, you will no longer be able to log in to the Customer Dashboard or access any account features. This is permanent — we cannot recover a deleted account.
+
+## What Is Deleted
+
+- Your account login and dashboard access
+- Your API tokens and usage history
+- Any personal data not subject to a regulatory retention requirement (see below)
+
+## What Is Retained
+
+The stock and options exchanges require Market Data to maintain records of all subscriber classifications (professional vs. non-professional) for a minimum of **3 years**. To comply with this obligation, we are required to retain the following even after account deletion:
+
+- Your name and employment information
+- Your professional/non-professional classification and the basis for that determination
+- Your signed exchange agreements
+
+This data is retained solely for regulatory compliance purposes. It is not used for marketing or any other purpose.
+
+Additionally, billing records held by our payment processor are subject to their own data retention policies and are outside of our control.
+
+## Before You Request Deletion
+
+- **Active subscriptions lose access immediately.** If you request deletion while you have an active paid subscription, your account will be deleted right away — you will not retain access for the remainder of your billing period. No prorated refunds will be issued. If you want to use your subscription through the end of the current billing period, request a [cancellation](/docs/account/cancellations/) instead. Cancellation stops future charges but keeps your account active until the period ends.
+- **Download your invoices.** Once your account is deleted, you will not be able to access the [Billing Portal](https://cc.payproglobal.com/Customer/Account/Login) to download past invoices. Download any invoices you need before requesting deletion.
+
+## Still Need Help?
+
+If you have questions about what data we hold or how deletion works, contact our [support helpdesk](https://www.marketdata.app/dashboard/) before submitting your request.
+
+We typically respond within a few hours during market hours or within 1 business day outside of market hours.

--- a/account/troubleshooting/billing-portal-access.md
+++ b/account/troubleshooting/billing-portal-access.md
@@ -1,0 +1,45 @@
+---
+title: Billing Portal Access
+sidebar_position: 7
+---
+
+## Problem Overview
+
+You are having trouble logging in to the [Billing Portal](https://cc.payproglobal.com/Customer/Account/Login) to manage your subscription, update your payment method, or view your invoices.
+
+## Common Issues
+
+### "I Don't Have a Billing Portal Account"
+
+The Billing Portal is only available to **paid customers**. A billing portal account is created automatically when you make your first purchase. If you have never had a paid subscription with Market Data, you do not have a billing portal account.
+
+- **Free Forever accounts** do not have billing portal access.
+- **Trial accounts** do not have billing portal access.
+
+If you are on a free or trial plan and want to subscribe, you can do so directly from the Market Data [Customer Dashboard](https://www.marketdata.app/dashboard/). A billing portal account will be created for you when you complete your first purchase.
+
+### "I Don't Know My Password"
+
+The Billing Portal is operated by a third-party payment processor (PayProGlobal) and is **completely separate** from your Market Data account. Your Market Data login credentials will not work in the Billing Portal.
+
+There is no initial password — you must create one the first time you log in:
+
+1. Visit the [Billing Portal](https://cc.payproglobal.com/Customer/Account/Login).
+2. Click **"Forgot Password"**.
+3. Enter the email address you used on the credit card payment form when you first subscribed.
+4. Follow the instructions in the password reset email to set your password.
+5. Log in with your new credentials.
+
+### "I'm Not Receiving the Password Reset Email"
+
+The password reset email is sent to the email address that was used on the **original credit card payment form** — not necessarily the email address currently on your Market Data account.
+
+If you have changed your email address with Market Data since your first purchase, the billing portal still uses the **original email from the payment form**. Try the password reset using that earlier email address.
+
+If you are unsure which email address was used, contact our [support helpdesk](https://www.marketdata.app/dashboard/) and we can help you identify the correct email.
+
+## Still Need Help?
+
+If you are still unable to access the Billing Portal, contact our [support helpdesk](https://www.marketdata.app/dashboard/). You can also request billing support directly through the [Billing Portal](https://cc.payproglobal.com/Customer/Account/Login) once logged in — see [Billing Portal](/docs/account/billing-portal/) for the full list of actions available.
+
+We typically respond within a few hours during market hours or within 1 business day outside of market hours.

--- a/account/troubleshooting/classification-dispute.md
+++ b/account/troubleshooting/classification-dispute.md
@@ -1,0 +1,71 @@
+---
+title: Disagree With Your Classification
+sidebar_position: 6
+---
+
+## Problem Overview
+
+You believe you should be classified as a non-professional data user, but Market Data has classified your account as professional. This page explains how classifications are determined, why your account may have been flagged, and what you can do if you believe the classification is incorrect.
+
+## How Professional Status Is Determined
+
+Professional status is not based on how you think of yourself — it is defined by the stock and options exchanges based on three objective criteria:
+
+1. **How you use the data** — Any use of market data for business or commercial purposes is professional use, even if the business is not in financial services.
+2. **Your job function** — Roles that involve trading, portfolio management, financial analysis, or investment advisory are classified as professional.
+3. **Registration** — Being registered or qualified with a securities regulatory body (SEC, FINRA, CFTC, FCA, etc.) typically qualifies as professional, even if you are not currently active.
+
+Market Data does not set these rules. They come directly from the exchanges and apply to all vendors who distribute real-time market data. See [Professional Status Policy](/docs/account/data-policies/professional-status/) for the full criteria, or read [Professional Status Explained](https://www.marketdata.app/education/stocks/professional-status-explained/) for a detailed guide with examples.
+
+## Common Reasons for Professional Classification
+
+### Using Data for a Business or Startup
+
+If you plan to use market data in connection with a business — including a startup, an LLC, or a side project — that is commercial use under exchange rules, regardless of whether:
+
+- The business is profitable yet
+- You are the sole owner or employee
+- The business is not in financial services
+- You personally paid for the subscription
+
+Any use of data to support a business function — such as building a product, providing a service, generating reports for clients, or integrating data into an application — is classified as professional. This includes personal LLCs, even single-member pass-through entities.
+
+Non-professional plans are for **personal, non-commercial use only**. If you need data for a business, you will need a professional or enterprise license.
+
+### Job Function Suggests Professional Use
+
+If your employer and job title suggest that your role involves securities-related activities, we may classify your account as professional even if you signed up under a personal account. This applies when your role involves:
+
+- Trading or executing securities, commodities, or derivatives
+- Managing investment portfolios or making investment decisions
+- Providing investment advice or financial planning to clients
+- Producing investment research
+- Developing software or systems that support investment activities
+
+For example, a financial analyst at an investment firm who signs up for a personal account would still be classified as professional, because their job function involves market data. The exchanges require this classification regardless of whether the individual intends to use the data at work or at home.
+
+## What You Can Do
+
+### If You Believe the Classification Is Wrong
+
+If you believe your role or intended use does not meet the criteria for professional status, contact our [support helpdesk](https://www.marketdata.app/dashboard/) and provide:
+
+- A clear description of your **day-to-day job responsibilities** (if the classification is based on your employer)
+- A description of **how you intend to use the data** (if the classification is based on commercial use)
+- Any supporting documentation — such as a LinkedIn profile, resume, or job description — that clarifies your role
+
+We will review the information and update your classification if the evidence supports it. Our goal is to classify every subscriber correctly — not to default to professional.
+
+### If the Classification Is Correct
+
+If your use case or job function does qualify as professional under exchange rules, your options are:
+
+- **Subscribe under a professional plan** with the appropriate exchange fees. Contact our [support helpdesk](https://www.marketdata.app/dashboard/) for pricing.
+- **Continue with delayed or historical data.** If you are not eligible for non-professional real-time data, you can still use Market Data to access delayed or historical data based on each exchange's policies.
+- **Cancel your subscription** if the pricing does not work for you. See [Cancellations](/docs/account/cancellations/).
+
+## Still Need Help?
+
+If you are unsure why your account was classified as professional, or if you want to discuss your specific situation, contact our [support helpdesk](https://www.marketdata.app/dashboard/). We are happy to walk you through the classification criteria and help you determine the correct status.
+
+We typically respond within a few hours during market hours or within 1 business day outside of market hours.

--- a/account/troubleshooting/financial-employer.md
+++ b/account/troubleshooting/financial-employer.md
@@ -1,0 +1,61 @@
+---
+title: Financial Industry Employer
+sidebar_position: 5
+---
+
+## Problem Overview
+
+Your account verification requires additional review because your employer is a bank, brokerage, insurance company, investment firm, or other financial institution. Working at a financial institution does not automatically make you a professional data user — but it does require us to look more closely at your actual job responsibilities before we can classify your account.
+
+## Why Financial Industry Employees Get Additional Review
+
+Exchange regulations require Market Data to classify every subscriber as either a professional or non-professional data user. For most subscribers, a job title and employer are enough to make this determination. But at financial institutions, the same company can employ both professional and non-professional users depending on the role:
+
+| Role | Classification | Reason |
+|------|---------------|--------|
+| Portfolio Manager | Professional | Makes investment decisions |
+| Investment Adviser | Professional | Provides tailored investment advice to clients |
+| Trader | Professional | Executes securities or derivatives trades |
+| Research Analyst | Professional | Produces investment research that influences trading decisions |
+| Software Developer (fin-tech) | Professional | Develops software that supports investment activities |
+| Administrative Assistant | Non-Professional | Provides administrative support without engaging in investment activities |
+| Customer Service Rep | Non-Professional | Handles inquiries without providing investment advice |
+| Compliance Officer | Non-Professional | Ensures regulatory compliance but does not engage in investment decisions |
+| HR Manager | Non-Professional | Manages human resources, not involved in investment activities |
+| Accountant | Non-Professional | Handles financial records and reporting, not directly involved in investments |
+
+Because we cannot determine your classification from your employer name alone, we need to understand what you actually do day-to-day.
+
+## How to Fix
+
+Contact our [support helpdesk](https://www.marketdata.app/dashboard/) and provide a brief description of your **actual daily job responsibilities**. Specifically, we need to know whether your role involves any of the following:
+
+- Trading, executing, or managing securities, commodities, or derivatives
+- Providing investment advice or recommendations to clients
+- Managing investment portfolios or making investment decisions
+- Producing research that influences trading or advisory decisions
+- Developing software or systems that directly support investment activities
+
+If your role does **not** involve any of the above — for example, if you work in IT, operations, HR, compliance, accounting, marketing, or administrative support — you will typically be classified as non-professional, even though your employer is a financial institution.
+
+### Supporting Documentation
+
+To speed up the review, you can also provide any of the following:
+
+- A link to your **LinkedIn profile** showing your current role and responsibilities
+- A **resume or CV** that describes your job function
+- A **company directory listing** or job description that outlines your responsibilities
+
+## What Determines Your Classification
+
+Your classification is based on your **job function**, not your employer. The key question is whether your day-to-day work involves securities-related activities — not whether the company you work for is in financial services.
+
+For example, a software developer at a social media company is non-professional, but a software developer at a fin-tech startup building trading tools is professional. The same logic applies within a bank: an HR manager is non-professional, but a relationship manager advising clients on investments is professional.
+
+See [Professional Status Policy](/docs/account/data-policies/professional-status/) for the full classification criteria, or read [Professional Status Explained](https://www.marketdata.app/education/stocks/professional-status-explained/) for a detailed guide with additional examples.
+
+## Still Need Help?
+
+If you are unsure how your role would be classified, contact our [support helpdesk](https://www.marketdata.app/dashboard/) and describe your day-to-day responsibilities. Our support team will let you know what classification applies.
+
+We typically respond within a few hours during market hours or within 1 business day outside of market hours.

--- a/account/troubleshooting/incomplete-profile.md
+++ b/account/troubleshooting/incomplete-profile.md
@@ -1,0 +1,54 @@
+---
+title: Incomplete Profile
+sidebar_position: 1
+---
+
+## Problem Overview
+
+Your account verification is delayed because your profile contains missing, vague, or placeholder information. Market Data must verify your identity and employment details before activating real-time data, and we cannot complete verification when required fields are incomplete or do not match third-party records.
+
+## Common Examples
+
+The following are examples of profile entries that will prevent verification from completing:
+
+### Employer Field
+
+- **"N/A"** or left blank — An employer is required for all subscribers. If you are retired or not working, see [Retired or Not Working](/docs/account/troubleshooting/retired-or-unemployed). If you are self-employed, see [Self-Employed or Business Owner](/docs/account/troubleshooting/self-employed).
+- **"Government"** — This is too vague. We need the specific agency or department (e.g., "U.S. Department of the Treasury" or "Ministry of Finance, UAE").
+- **A job title instead of an employer** — For example, entering "Software Engineer" or "Investor" in the employer field. The employer field must contain the name of the company or organization you work for.
+
+### Job Title Field
+
+- **"N/A"**, **"Investor"**, or left blank — A specific job title is required. "Investor" is not a job title — it describes how you intend to use the data, not your employment.
+- **An employer name instead of a job title** — The job title field should describe your role (e.g., "Financial Analyst", "IT Manager", "Retired").
+- **Same value in both fields** — Entering your job title in both the employer and job title fields, or your employer name in both fields.
+
+### Contact Information
+
+- **Incomplete address** — A full mailing address is required, including city, state/province, and country.
+- **Invalid phone number** — The phone number must be a working number where you can be reached.
+
+## Why This Is Required
+
+Market Data is required by the stock and options exchanges to verify the identity and employment of every paid subscriber before granting access to real-time data. We cross-reference the information you provide against third-party databases, including LinkedIn and FINRA BrokerCheck, to classify you as a professional or non-professional user.
+
+When fields are missing or contain placeholder values, we cannot complete this verification and your account remains in a pending state. See [Account Verification Policy](/docs/account/data-policies/account-verification/) for full details.
+
+## How to Fix
+
+1. Log in to the [Customer Dashboard](https://www.marketdata.app/dashboard/).
+2. Navigate to your profile settings.
+3. Update all fields with accurate, specific information:
+   - **Employer**: The full legal name of the company or organization you work for.
+   - **Job Title**: Your actual role or position at that company.
+   - **Address**: Your complete mailing address.
+   - **Phone Number**: A valid phone number.
+4. Save your changes.
+
+Once your profile is updated, verification will be completed within 1 business day.
+
+## Still Need Help?
+
+If you have updated your profile and your account has not been activated, please contact our [support helpdesk](https://www.marketdata.app/dashboard/) and let our support team know that you have updated your profile with complete information.
+
+We typically respond within a few hours during market hours or within 1 business day outside of market hours.

--- a/account/troubleshooting/index.mdx
+++ b/account/troubleshooting/index.mdx
@@ -1,0 +1,25 @@
+---
+title: Troubleshooting
+sidebar_position: 13
+---
+
+This section covers common account issues and how to resolve them. Most problems are related to account verification — specifically, providing incomplete or insufficient information during sign-up.
+
+## Account Verification
+
+After you subscribe to a paid plan, Market Data must verify your identity and employment information before activating real-time data on your account. This is a requirement of the stock and options exchanges. If your profile is incomplete or doesn't match third-party records, verification will be delayed.
+
+- [Incomplete Profile](/docs/account/troubleshooting/incomplete-profile) — Missing or vague employer, job title, or contact information.
+- [No LinkedIn Profile](/docs/account/troubleshooting/linkedin-missing) — How to verify your account without a LinkedIn profile.
+- [Retired or Not Working](/docs/account/troubleshooting/retired-or-unemployed) — Work history requirements for subscribers who are not currently employed.
+- [Self-Employed or Business Owner](/docs/account/troubleshooting/self-employed) — Additional documentation needed when you own or operate a business.
+- [Financial Industry Employer](/docs/account/troubleshooting/financial-employer) — Why subscribers at banks, brokerages, and financial institutions receive additional review.
+- [Disagree With Your Classification](/docs/account/troubleshooting/classification-dispute) — What to do if you believe your professional/non-professional classification is incorrect.
+
+## Billing
+
+- [Billing Portal Access](/docs/account/troubleshooting/billing-portal-access) — Problems accessing the billing portal or managing your subscription.
+
+## Account Management
+
+- [Account Deletion](/docs/account/troubleshooting/account-deletion) — How to request deletion of your account and personal data.

--- a/account/troubleshooting/linkedin-missing.md
+++ b/account/troubleshooting/linkedin-missing.md
@@ -1,0 +1,53 @@
+---
+title: No LinkedIn Profile
+sidebar_position: 2
+---
+
+## Problem Overview
+
+Your account verification is delayed because we cannot verify your employment information from the LinkedIn profile you provided. This happens when your LinkedIn profile is missing, set to private, or does not contain enough information to confirm your current employer and job title.
+
+## Common Scenarios
+
+- **No LinkedIn profile provided** — You entered the placeholder URL (`https://www.linkedin.com`) or left the field blank.
+- **Broken URL** — The LinkedIn link you provided does not work or leads to a page that does not exist.
+- **Company page instead of personal profile** — You provided a link to your company's LinkedIn page instead of your own. A company page tells us where you work, but not your specific role.
+- **Private profile** — Your LinkedIn profile is set to private, so we cannot view your employment history.
+- **Stub profile** — You created a LinkedIn profile to complete the sign-up form, but it does not list your employer, job title, or work history. A profile with only a name and photo is not sufficient for verification.
+
+## Why We Need This
+
+Market Data is required by the stock and options exchanges to verify the identity and employment of every paid subscriber before granting access to real-time data. A LinkedIn profile is the fastest way for us to do this because it is a widely used, publicly accessible professional database.
+
+When we cannot verify your employment through LinkedIn, we need alternative documentation to complete the process. See [Account Verification Policy](/docs/account/data-policies/account-verification/) for full details.
+
+## How to Fix
+
+You have two options:
+
+### Option 1: Update Your LinkedIn Profile
+
+If you have a LinkedIn profile, make sure it is:
+
+- Set to **public** (at least your employment section)
+- Updated with your **current employer** and **job title**
+
+Once updated, contact our [support helpdesk](https://www.marketdata.app/dashboard/) with a link to your profile.
+
+### Option 2: Provide Alternative Documentation
+
+If you do not have a LinkedIn profile or prefer not to use one, you can provide any of the following:
+
+- A current resume or CV
+- A photo of your business card showing your current job title and employer
+- A recent paystub (please redact any sensitive financial data)
+- A company directory or website listing that shows your name and role
+- Any other document that confirms your current employer and role
+
+This documentation helps us confirm your employment so we can classify your account correctly and ensure you receive the appropriate pricing for market data access.
+
+## Still Need Help?
+
+If you are unsure what documentation to provide, please contact our [support helpdesk](https://www.marketdata.app/dashboard/) and our support team will let you know exactly what is needed to complete your verification.
+
+We typically respond within a few hours during market hours or within 1 business day outside of market hours.

--- a/account/troubleshooting/retired-or-unemployed.md
+++ b/account/troubleshooting/retired-or-unemployed.md
@@ -1,0 +1,51 @@
+---
+title: Retired or Not Working
+sidebar_position: 3
+---
+
+## Problem Overview
+
+Your account verification is delayed because you indicated that you are retired or not currently employed, but we do not have sufficient documentation to confirm this. The stock and options exchanges require us to independently verify the employment status of every paid subscriber before activating real-time data — a self-reported status of "retired" alone is not sufficient.
+
+## Why This Is Required
+
+Exchange regulations require Market Data to classify every subscriber as either a professional or non-professional data user. We cannot classify you as non-professional until we receive external confirmation that you are no longer employed in a role that would qualify as professional use.
+
+These rules come directly from the exchanges and apply before we can activate access to real-time market data. See [Account Verification Policy](/docs/account/data-policies/account-verification/) and [Professional Status Policy](/docs/account/data-policies/professional-status/) for full details.
+
+## How to Fix
+
+Provide **one** of the following documents to confirm your retirement or unemployment status:
+
+1. A link to your **LinkedIn profile** that clearly shows your most recent role with an **end date**, or otherwise indicates that you are retired.
+2. A **resume or CV** that includes the **end date of your last position** and indicates you are no longer working.
+3. An official **retirement letter** or documentation from your previous employer.
+4. A **pension award letter**, **Social Security benefit statement**, or other government retirement document.
+5. **Tax documentation** showing retirement income (e.g., Form 1099-R in the U.S.). You may redact your Social Security Number and any other sensitive financial details — we only need to confirm that the document reflects retirement income.
+6. Any other reasonable documentation that confirms you are no longer actively employed in any professional capacity.
+
+Contact our [support helpdesk](https://www.marketdata.app/dashboard/) with any of the documents listed above. All documentation will remain confidential and used solely to verify your status.
+
+### What We Look For
+
+The key detail in any document is a **clear end date** for your most recent position. A LinkedIn profile or resume that only lists a job title and employer without an end date does not confirm that you have left the role — it looks the same as a current position.
+
+## Special Circumstances
+
+### Consulting or Part-Time Work
+
+If you are doing consulting work, even on a part-time basis, this may affect your classification. Include details about the nature of the consulting you perform when contacting support so we can determine the correct classification.
+
+### Retired From One Field, Working in Another
+
+If you have retired from one career but are now working in a different field, please provide details of your current role. As long as the work is not securities-related, we can typically classify your account as non-professional.
+
+### Selected "Retired" for Privacy Reasons
+
+If you are still employed and selected "retired" because you preferred not to share your employment details, you can simply provide your current job title and employer instead. As long as your work is not securities-related, we can typically process your account as non-professional. See [Account Verification Policy](/docs/account/data-policies/account-verification/) for details on what information we collect and how we use it.
+
+## Still Need Help?
+
+If you are unsure what documentation to provide, please contact our [support helpdesk](https://www.marketdata.app/dashboard/) and our support team will let you know exactly what is needed to complete your verification.
+
+We typically respond within a few hours during market hours or within 1 business day outside of market hours.

--- a/account/troubleshooting/self-employed.md
+++ b/account/troubleshooting/self-employed.md
@@ -1,0 +1,66 @@
+---
+title: Self-Employed or Business Owner
+sidebar_position: 4
+---
+
+## Problem Overview
+
+Your account verification is delayed because you indicated that you are self-employed or own a business, but we cannot determine what your business does. When there is no public information available about your business — no website, no LinkedIn page, no public filings describing the business activity — we need additional documentation before we can classify your account.
+
+## Why This Is Required
+
+Exchange regulations require Market Data to classify every subscriber as either a professional or non-professional data user. For self-employed subscribers, the classification depends on the nature of the business itself — specifically, whether the business is involved in financial services, investment management, or other activities that would qualify as professional use under exchange rules.
+
+A self-reported business name alone is not sufficient. We need to independently confirm what the business does. See [Account Verification Policy](/docs/account/data-policies/account-verification/) and [Professional Status Policy](/docs/account/data-policies/professional-status/) for full details.
+
+## How to Fix
+
+### Option 1: Provide a Public Link
+
+The fastest way to resolve this is to provide a link to any public source that describes your business:
+
+- A business website
+- A company LinkedIn page
+- A business directory listing
+- A public filing that describes the nature of the business
+
+Contact our [support helpdesk](https://www.marketdata.app/dashboard/) with the link and we can typically verify your account the same day.
+
+### Option 2: Answer a Few Questions
+
+If your business does not have a public presence, contact our [support helpdesk](https://www.marketdata.app/dashboard/) with the following information:
+
+1. The **registered name** of your business (if applicable).
+2. Your **primary business activities and services** — what does the business do?
+3. Whether your business:
+   - Provides any investment advice or recommendations
+   - Manages investments for others
+   - Uses market data as part of its products or services
+   - Shares or redistributes market data to others
+
+If your business is not involved in any of the above, we can typically classify your account as non-professional.
+
+### Option 3: Provide Supporting Documentation
+
+You can also send any document that confirms your line of business:
+
+- A business registration or filing that describes the nature of the business
+- A brochure or marketing materials describing your products or services
+- Any other document that makes clear what the business does
+
+## What Triggers Professional Classification
+
+Your business activity — not your job title — determines your classification. Businesses that do any of the following are generally classified as professional:
+
+- Provide investment advice or financial planning
+- Manage investments or trade on behalf of others
+- Use market data as part of a commercial product or service
+- Redistribute or display market data to third parties
+
+If your business is in a non-financial field (e.g., construction, healthcare, retail, technology), you will typically be classified as non-professional regardless of the fact that you are self-employed.
+
+## Still Need Help?
+
+If you are unsure how your business would be classified, please contact our [support helpdesk](https://www.marketdata.app/dashboard/) and describe what your business does. Our support team will let you know what classification applies and what documentation, if any, is needed.
+
+We typically respond within a few hours during market hours or within 1 business day outside of market hours.


### PR DESCRIPTION
## Summary
- Add new troubleshooting section under Account with 8 articles covering verification issues (incomplete profile, missing LinkedIn, retired/unemployed, self-employed, financial employer, classification disputes), billing portal access, and account deletion
- Add cross-link from account verification policy page to the new troubleshooting section

## Test plan
- [x] Docusaurus build passes
- [x] Integration tests pass on staging
- [x] E2E tests pass on staging
- [x] Sidebar ordering verified — no gaps or duplicates