### PR TITLE
ci: migrate slack notifications + linkedin troubleshooting rework

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -120,15 +120,8 @@ jobs:
       - name: Notify Slack on failure
         if: failure()
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_ALERTS_WEBHOOK_URL }}
-          REPO: ${{ github.repository }}
-          WORKFLOW: ${{ github.workflow }}
-          BRANCH: ${{ github.ref_name }}
-          SHA: ${{ github.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_NOTIFY_URL: ${{ secrets.SLACK_NOTIFY_URL }}
+          SLACK_NOTIFY_TOKEN: ${{ secrets.SLACK_NOTIFY_TOKEN }}
         run: |
-          SHORT_SHA="${SHA:0:7}"
-          printf '🔴 WORKFLOW FAILED — %s\nRepo: %s\nBranch: %s @ %s\n%s' \
-            "$WORKFLOW" "$REPO" "$BRANCH" "$SHORT_SHA" "$RUN_URL" \
-            | jq -Rs '{text: .}' \
-            | curl -s -X POST "$SLACK_WEBHOOK" -H 'Content-Type: application/json' -d @-
+          curl -s -d "" \
+            "${SLACK_NOTIFY_URL}?token=${SLACK_NOTIFY_TOKEN}&type=ci_failure&channel=alerts&workflow=${GITHUB_WORKFLOW}&repo=${GITHUB_REPOSITORY}&branch=${GITHUB_REF_NAME}&sha=${GITHUB_SHA:0:7}&run_id=${GITHUB_RUN_ID}"

--- a/.github/workflows/post-deploy-tests.yml
+++ b/.github/workflows/post-deploy-tests.yml
@@ -40,15 +40,8 @@ jobs:
       - name: Notify Slack on failure
         if: failure()
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_ALERTS_WEBHOOK_URL }}
-          REPO: ${{ github.repository }}
-          WORKFLOW: ${{ github.workflow }}
-          BRANCH: ${{ github.ref_name }}
-          SHA: ${{ github.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_NOTIFY_URL: ${{ secrets.SLACK_NOTIFY_URL }}
+          SLACK_NOTIFY_TOKEN: ${{ secrets.SLACK_NOTIFY_TOKEN }}
         run: |
-          SHORT_SHA="${SHA:0:7}"
-          printf '🔴 WORKFLOW FAILED — %s\nRepo: %s\nBranch: %s @ %s\n%s' \
-            "$WORKFLOW" "$REPO" "$BRANCH" "$SHORT_SHA" "$RUN_URL" \
-            | jq -Rs '{text: .}' \
-            | curl -s -X POST "$SLACK_WEBHOOK" -H 'Content-Type: application/json' -d @-
+          curl -s -d "" \
+            "${SLACK_NOTIFY_URL}?token=${SLACK_NOTIFY_TOKEN}&type=ci_failure&channel=alerts&workflow=${GITHUB_WORKFLOW}&repo=${GITHUB_REPOSITORY}&branch=${GITHUB_REF_NAME}&sha=${GITHUB_SHA:0:7}&run_id=${GITHUB_RUN_ID}"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -57,18 +57,11 @@ jobs:
       - name: Notify Slack on failure
         if: failure()
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_ALERTS_WEBHOOK_URL }}
-          REPO: ${{ github.repository }}
-          WORKFLOW: ${{ github.workflow }}
-          BRANCH: ${{ github.ref_name }}
-          SHA: ${{ github.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_NOTIFY_URL: ${{ secrets.SLACK_NOTIFY_URL }}
+          SLACK_NOTIFY_TOKEN: ${{ secrets.SLACK_NOTIFY_TOKEN }}
         run: |
-          SHORT_SHA="${SHA:0:7}"
-          printf '🔴 WORKFLOW FAILED — %s\nRepo: %s\nBranch: %s @ %s\n%s' \
-            "$WORKFLOW" "$REPO" "$BRANCH" "$SHORT_SHA" "$RUN_URL" \
-            | jq -Rs '{text: .}' \
-            | curl -s -X POST "$SLACK_WEBHOOK" -H 'Content-Type: application/json' -d @-
+          curl -s -d "" \
+            "${SLACK_NOTIFY_URL}?token=${SLACK_NOTIFY_TOKEN}&type=ci_failure&channel=alerts&workflow=${GITHUB_WORKFLOW}&repo=${GITHUB_REPOSITORY}&branch=${GITHUB_REF_NAME}&sha=${GITHUB_SHA:0:7}&run_id=${GITHUB_RUN_ID}"
 
   staging-e2e-tests:
     runs-on: ubuntu-latest
@@ -92,15 +85,8 @@ jobs:
       - name: Notify Slack on failure
         if: failure()
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_ALERTS_WEBHOOK_URL }}
-          REPO: ${{ github.repository }}
-          WORKFLOW: ${{ github.workflow }}
-          BRANCH: ${{ github.ref_name }}
-          SHA: ${{ github.sha }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SLACK_NOTIFY_URL: ${{ secrets.SLACK_NOTIFY_URL }}
+          SLACK_NOTIFY_TOKEN: ${{ secrets.SLACK_NOTIFY_TOKEN }}
         run: |
-          SHORT_SHA="${SHA:0:7}"
-          printf '🔴 WORKFLOW FAILED — %s\nRepo: %s\nBranch: %s @ %s\n%s' \
-            "$WORKFLOW" "$REPO" "$BRANCH" "$SHORT_SHA" "$RUN_URL" \
-            | jq -Rs '{text: .}' \
-            | curl -s -X POST "$SLACK_WEBHOOK" -H 'Content-Type: application/json' -d @-
+          curl -s -d "" \
+            "${SLACK_NOTIFY_URL}?token=${SLACK_NOTIFY_TOKEN}&type=ci_failure&channel=alerts&workflow=${GITHUB_WORKFLOW}&repo=${GITHUB_REPOSITORY}&branch=${GITHUB_REF_NAME}&sha=${GITHUB_SHA:0:7}&run_id=${GITHUB_RUN_ID}"

--- a/account/troubleshooting/financial-employer.md
+++ b/account/troubleshooting/financial-employer.md
@@ -11,18 +11,18 @@ Your account verification requires additional review because your employer is a 
 
 Exchange regulations require Market Data to classify every subscriber as either a professional or non-professional data user. For most subscribers, a job title and employer are enough to make this determination. But at financial institutions, the same company can employ both professional and non-professional users depending on the role:
 
-| Role | Classification | Reason |
-|------|---------------|--------|
-| Portfolio Manager | Professional | Makes investment decisions |
-| Investment Adviser | Professional | Provides tailored investment advice to clients |
-| Trader | Professional | Executes securities or derivatives trades |
-| Research Analyst | Professional | Produces investment research that influences trading decisions |
-| Software Developer (fin-tech) | Professional | Develops software that supports investment activities |
-| Administrative Assistant | Non-Professional | Provides administrative support without engaging in investment activities |
-| Customer Service Rep | Non-Professional | Handles inquiries without providing investment advice |
-| Compliance Officer | Non-Professional | Ensures regulatory compliance but does not engage in investment decisions |
-| HR Manager | Non-Professional | Manages human resources, not involved in investment activities |
-| Accountant | Non-Professional | Handles financial records and reporting, not directly involved in investments |
+| Role                          | Classification   | Reason                                                                        |
+|-------------------------------|------------------|-------------------------------------------------------------------------------|
+| Portfolio Manager             | Professional     | Makes investment decisions                                                    |
+| Investment Adviser            | Professional     | Provides tailored investment advice to clients                                |
+| Trader                        | Professional     | Executes securities or derivatives trades                                     |
+| Research Analyst              | Professional     | Produces investment research that influences trading decisions                |
+| Software Developer (fin-tech) | Professional     | Develops software that supports investment activities                         |
+| Administrative Assistant      | Non-Professional | Provides administrative support without engaging in investment activities     |
+| Customer Service Rep          | Non-Professional | Handles inquiries without providing investment advice                         |
+| Compliance Officer            | Non-Professional | Ensures regulatory compliance but does not engage in investment decisions     |
+| HR Manager                    | Non-Professional | Manages human resources, not involved in investment activities                |
+| Accountant                    | Non-Professional | Handles financial records and reporting, not directly involved in investments |
 
 Because we cannot determine your classification from your employer name alone, we need to understand what you actually do day-to-day.
 

--- a/account/troubleshooting/index.mdx
+++ b/account/troubleshooting/index.mdx
@@ -10,7 +10,7 @@ This section covers common account issues and how to resolve them. Most problems
 After you subscribe to a paid plan, Market Data must verify your identity and employment information before activating real-time data on your account. This is a requirement of the stock and options exchanges. If your profile is incomplete or doesn't match third-party records, verification will be delayed.
 
 - [Incomplete Profile](/docs/account/troubleshooting/incomplete-profile) — Missing or vague employer, job title, or contact information.
-- [No LinkedIn Profile](/docs/account/troubleshooting/linkedin-missing) — How to verify your account without a LinkedIn profile.
+- [LinkedIn Profile Issues](/docs/account/troubleshooting/linkedin-issues) — Fixing missing, private, outdated, or mismatched LinkedIn profiles (or verifying without one).
 - [Retired or Not Working](/docs/account/troubleshooting/retired-or-unemployed) — Work history requirements for subscribers who are not currently employed.
 - [Self-Employed or Business Owner](/docs/account/troubleshooting/self-employed) — Additional documentation needed when you own or operate a business.
 - [Financial Industry Employer](/docs/account/troubleshooting/financial-employer) — Why subscribers at banks, brokerages, and financial institutions receive additional review.

--- a/account/troubleshooting/linkedin-issues.md
+++ b/account/troubleshooting/linkedin-issues.md
@@ -1,11 +1,11 @@
 ---
-title: No LinkedIn Profile
+title: LinkedIn Profile Issues
 sidebar_position: 2
 ---
 
 ## Problem Overview
 
-Your account verification is delayed because we cannot verify your employment information from the LinkedIn profile you provided. This happens when your LinkedIn profile is missing, set to private, or does not contain enough information to confirm your current employer and job title.
+Your account verification is delayed because we cannot verify your employment information from the LinkedIn profile you provided. This is one of the most common reasons for verification delays — more often than not, the profile is unusable rather than missing entirely.
 
 ## Common Scenarios
 
@@ -14,10 +14,12 @@ Your account verification is delayed because we cannot verify your employment in
 - **Company page instead of personal profile** — You provided a link to your company's LinkedIn page instead of your own. A company page tells us where you work, but not your specific role.
 - **Private profile** — Your LinkedIn profile is set to private, so we cannot view your employment history.
 - **Stub profile** — You created a LinkedIn profile to complete the sign-up form, but it does not list your employer, job title, or work history. A profile with only a name and photo is not sufficient for verification.
+- **Name mismatch** — The name on your LinkedIn profile does not match the name on your data use profile. We cannot confirm that the LinkedIn profile belongs to you if the names do not match.
+- **Employment mismatch** — The employment on your data use profile does not match what your LinkedIn profile shows. For example, you declared one employer or job title but your LinkedIn shows a different active role. We cannot confirm your declared employment when the two sources disagree.
 
 ## Why We Need This
 
-Market Data is required by the stock and options exchanges to verify the identity and employment of every paid subscriber before granting access to real-time data. A LinkedIn profile is the fastest way for us to do this because it is a widely used, publicly accessible professional database.
+Market Data is required by the stock and options exchanges to verify the identity and employment of every paid subscriber before granting access to data. A LinkedIn profile is the fastest way for us to do this because it is a widely used, publicly accessible professional database.
 
 When we cannot verify your employment through LinkedIn, we need alternative documentation to complete the process. See [Account Verification Policy](/docs/account/data-policies/account-verification/) for full details.
 
@@ -25,12 +27,16 @@ When we cannot verify your employment through LinkedIn, we need alternative docu
 
 You have two options:
 
-### Option 1: Update Your LinkedIn Profile
+### Option 1: Fix Your LinkedIn Profile
 
-If you have a LinkedIn profile, make sure it is:
+Make sure your LinkedIn profile is:
 
-- Set to **public** (at least your employment section)
-- Updated with your **current employer** and **job title**
+- **Public** (at least your employment section)
+- **Accessible** via the URL you provided
+- **A personal profile**, not a company page
+- **Consistent** — the employment shown matches what you declared on your data use profile (if a role has ended, make sure it has an end date)
+- **Matches the name** on your data use profile
+- **Complete enough** to confirm your role (more than just a name and photo)
 
 Once updated, contact our [support helpdesk](https://www.marketdata.app/dashboard/) with a link to your profile.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -84,6 +84,10 @@ const config = {
       {
         redirects: [
           {
+            from: "/account/troubleshooting/linkedin-missing",
+            to: "/account/troubleshooting/linkedin-issues",
+          },
+          {
             from: "/api/troubleshooting/http-status-codes",
             to: "/api/troubleshooting",
           },


### PR DESCRIPTION
## Summary
- Migrate all 4 Slack failure notifications (`deploy-docs.yml`, `pr-checks.yml` ×2, `post-deploy-tests.yml`) from the direct webhook (`SLACK_ALERTS_WEBHOOK_URL`) to the centralized notify service (`SLACK_NOTIFY_URL` + `SLACK_NOTIFY_TOKEN`), matching the pattern used in `marketdata-amember`.
- Rework LinkedIn troubleshooting page to cover all profile issues (not just "missing").

## Test plan
- [ ] `deploy-docs.yml` completes successfully on merge
- [ ] `post-deploy-tests.yml` canonical check for `/docs/account/troubleshooting/linkedin-missing/` passes once prod has the renamed `linkedin-issues` page
- [ ] Slack failure notifications route correctly (can verify by inducing a failure later, or trust the amember parity)