### PR TITLE
docs(sdk/js): drop stale 'user' from utilities resource list

### DIFF
--- a/sdk/js/client.mdx
+++ b/sdk/js/client.mdx
@@ -58,7 +58,7 @@ interface MarketDataConfig {
 - `options` ([OptionsResource](/sdk/js/options)): Access to options endpoints (chain, expirations, quotes, lookup)
 - `funds` ([FundsResource](/sdk/js/funds)): Access to funds endpoints (candles)
 - `markets` ([MarketsResource](/sdk/js/markets)): Access to markets endpoints (status)
-- `utilities` ([UtilitiesResource](/sdk/js/utilities)): Access to utility endpoints (`status`, `headers`, `user`)
+- `utilities` ([UtilitiesResource](/sdk/js/utilities)): Access to utility endpoints (`status`, `headers`)
 
 <a name="MarketDataClient.constructor"></a>
 ### constructor


### PR DESCRIPTION
## Summary
- Line 61 of `sdk/js/client.mdx` still listed `user` in the utilities endpoint list, but `utilities/user.mdx` was removed within PR #148 (the live SDK is also dropping `client.utilities.user()` in [sdk-js PR #24](https://github.com/MarketDataApp/sdk-js/pull/24)).

## Test plan
- [ ] Verify the resource list on `www-staging.marketdata.app/docs/sdk/js/client/` shows utilities as only `status`, `headers`.