### PR TITLE
docs(api): replace NodeJS raw-fetch tabs with JavaScript + TypeScript…

### DIFF
--- a/api/authentication.mdx
+++ b/api/authentication.mdx
@@ -44,43 +44,46 @@ The curly braces around token are a placeholder for this example. Do not actuall
 :::
 
 </TabItem>
-<TabItem value="Node.js" label="Node.js">
+<TabItem value="JavaScript" label="JavaScript">
 
-```javascript
-const https = require('https');
+```js title="app.js"
+import { MarketDataClient } from "marketdata-sdk";
 
-// Your token
-const token = 'your_token_here';
+// The SDK reads your token from the MARKETDATA_TOKEN environment variable.
+// Alternatively, pass it directly: new MarketDataClient({ token: "your_token_here" })
+const client = new MarketDataClient();
 
-// The API endpoint for retrieving stock quotes for SPY
-const url = 'https://api.marketdata.app/v1/stocks/quotes/SPY/';
-
-// Making the GET request to the API
-https.get(url, {
-    headers: {
-        'Accept': 'application/json',
-        'Authorization': `Bearer ${token}`
-    }
-}, (response) => {
-    let data = '';
-
-    // A chunk of data has been received.
-    response.on('data', (chunk) => {
-        data += chunk;
-    });
-
-    // The whole response has been received. Print out the result.
-    response.on('end', () => {
-        if (response.statusCode === 200 || response.statusCode === 203) {
-            console.log(JSON.parse(data));
-        } else {
-            console.log(`Failed to retrieve data: ${response.statusCode}`);
-        }
-    });
-}).on("error", (err) => {
-    console.log("Error: " + err.message);
-});
+try {
+  const quotes = await client.stocks.quotes("SPY");
+  console.log(quotes);
+} catch (error) {
+  console.error(error);
+}
 ```
+
+For more information about using the JavaScript SDK, see our [JavaScript SDK documentation](/sdk/js) and [authentication guide](/sdk/js/authentication).
+
+</TabItem>
+
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="app.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { StockQuote } from "marketdata-sdk";
+
+// The SDK reads your token from the MARKETDATA_TOKEN environment variable.
+// Alternatively, pass it directly: new MarketDataClient({ token: "your_token_here" })
+const client = new MarketDataClient();
+
+try {
+  const quotes: StockQuote[] = await client.stocks.quotes("SPY");
+  console.log(quotes);
+} catch (error) {
+  console.error(error);
+}
+```
+
+For more information about using the JavaScript SDK, see our [JavaScript SDK documentation](/sdk/js) and [authentication guide](/sdk/js/authentication).
 
 </TabItem>
 

--- a/api/funds/candles.mdx
+++ b/api/funds/candles.mdx
@@ -30,19 +30,42 @@ GET
 **GET** [https://api.marketdata.app/v1/funds/candles/D/VFINX/?from=2020-01-01&to=2020-01-10](https://api.marketdata.app/v1/funds/candles/D/VFINX/?from=2020-01-01&to=2020-01-10)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="fundCandles.js"
-fetch(
-  "https://api.marketdata.app/v1/funds/candles/D/VFINX/?from=2020-01-01&to=2020-01-10"
-)
-  .then((res) => {
-    console.log(res);
-  })
-  .catch((err) => {
-    console.log(err);
-  });
+import { MarketDataClient } from "marketdata-sdk";
 
+const client = new MarketDataClient();
+
+try {
+  // VFINX is available without authentication (free test symbol).
+  const candles = await client.funds.candles("VFINX", { countback: 30 });
+  for (const c of candles) {
+    console.log(`t=${c.t} o=${c.o} h=${c.h} l=${c.l} c=${c.c}`);
+  }
+} catch (error) {
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="fundCandles.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { FundsCandle } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  // VFINX is available without authentication (free test symbol).
+  const candles: FundsCandle[] = await client.funds.candles("VFINX", { countback: 30 });
+  for (const c of candles) {
+    console.log(`t=${c.t} o=${c.o} h=${c.h} l=${c.l} c=${c.c}`);
+  }
+} catch (error) {
+  console.error(error);
+}
 ```
 
 </TabItem>

--- a/api/markets/status.mdx
+++ b/api/markets/status.mdx
@@ -26,26 +26,46 @@ GET
 **GET** [https://api.marketdata.app/v1/markets/status/?date=yesterday](https://api.marketdata.app/v1/markets/status/?date=yesterday)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="app.js"
-fetch(
-  "https://api.marketdata.app/v1/markets/status/?from=2020-01-01&to=2020-12-31"
-)
-  .then((res) => {
-    console.log(res);
-  })
-  .catch((err) => {
-    console.log(err);
-  });
+import { MarketDataClient } from "marketdata-sdk";
 
-fetch("https://api.marketdata.app/v1/markets/status/?date=yesterday")
-  .then((res) => {
-    console.log(res);
-  })
-  .catch((err) => {
-    console.log(err);
-  });
+const client = new MarketDataClient();
+
+try {
+  const days = await client.markets.status({ from: "2020-01-01", to: "2020-12-31" });
+  for (const d of days) {
+    console.log(`date=${d.date} status=${d.status}`);
+  }
+
+  const yesterday = await client.markets.status({ date: "yesterday" });
+  console.log(yesterday[0]);
+} catch (error) {
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="app.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { MarketStatusResponse } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const days: MarketStatusResponse = await client.markets.status({ from: "2020-01-01", to: "2020-12-31" });
+  for (const d of days) {
+    console.log(`date=${d.date} status=${d.status}`);
+  }
+
+  const yesterday: MarketStatusResponse = await client.markets.status({ date: "yesterday" });
+  console.log(yesterday[0]);
+} catch (error) {
+  console.error(error);
+}
 ```
 
 </TabItem>

--- a/api/options/chain.mdx
+++ b/api/options/chain.mdx
@@ -22,16 +22,36 @@ GET https://api.marketdata.app/v1/options/chain/{underlyingSymbol}/
 **GET** [https://api.marketdata.app/v1/options/chain/AAPL/?expiration=2025-01-17&side=call](https://api.marketdata.app/v1/options/chain/AAPL/?expiration=2025-01-17&side=call)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="app.js"
-fetch("https://api.marketdata.app/v1/options/chain/AAPL/")
-  .then((res) => {
-    console.log(res);
-  })
-  .catch((err) => {
-    console.log(err);
-  });
+import { MarketDataClient } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const contracts = await client.options.chain("AAPL");
+  console.log(`Got ${contracts.length} contracts`);
+} catch (error) {
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="app.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { OptionsChain } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const contracts: OptionsChain[] = await client.options.chain("AAPL");
+  console.log(`Got ${contracts.length} contracts`);
+} catch (error) {
+  console.error(error);
+}
 ```
 
 </TabItem>

--- a/api/options/expirations.mdx
+++ b/api/options/expirations.mdx
@@ -24,16 +24,42 @@ GET
 **GET** [https://api.marketdata.app/v1/options/expirations/AAPL/](https://api.marketdata.app/v1/options/expirations/AAPL/)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="app.js"
-fetch("https://api.marketdata.app/v1/options/expirations/AAPL/")
-  .then((res) => {
-    console.log(res);
-  })
-  .catch((err) => {
-    console.log(err);
-  });
+import { MarketDataClient } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const data = await client.options.expirations("AAPL");
+  console.log(`Updated: ${data.updated}`);
+  for (const exp of data.expirations) {
+    console.log(exp);
+  }
+} catch (error) {
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="app.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { OptionsExpirationsResponse } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const data: OptionsExpirationsResponse = await client.options.expirations("AAPL");
+  console.log(`Updated: ${data.updated}`);
+  for (const exp of data.expirations) {
+    console.log(exp);
+  }
+} catch (error) {
+  console.error(error);
+}
 ```
 
 </TabItem>

--- a/api/options/lookup.mdx
+++ b/api/options/lookup.mdx
@@ -24,18 +24,36 @@ GET
 **GET** [https://api.marketdata.app/v1/options/lookup/AAPL%207/28/2023%20200%20Call/](https://api.marketdata.app/v1/options/lookup/AAPL%207/28/2023%20200%20Call/)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="app.js"
-fetch(
-  "https://api.marketdata.app/v1/options/lookup/AAPL%207/28/2023%20200%20Call/"
-)
-  .then((res) => {
-    console.log(res);
-  })
-  .catch((err) => {
-    console.log(err);
-  });
+import { MarketDataClient } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const data = await client.options.lookup("AAPL 7/28/2023 200 Call");
+  console.log(data.optionSymbol);  // "AAPL230728C00200000"
+} catch (error) {
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="app.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { OptionsLookupResponse } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const data: OptionsLookupResponse = await client.options.lookup("AAPL 7/28/2023 200 Call");
+  console.log(data.optionSymbol);  // "AAPL230728C00200000"
+} catch (error) {
+  console.error(error);
+}
 ```
 
 </TabItem>

--- a/api/options/quotes.mdx
+++ b/api/options/quotes.mdx
@@ -28,16 +28,42 @@ GET
 **GET** [https://api.marketdata.app/v1/options/quotes/AAPL271217C00250000/](https://api.marketdata.app/v1/options/quotes/AAPL271217C00250000/)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="app.js"
-fetch("https://api.marketdata.app/v1/options/quotes/AAPL271217C00250000/")
-  .then((res) => {
-    console.log(res);
-  })
-  .catch((err) => {
-    console.log(err);
-  });
+import { MarketDataClient } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const quotes = await client.options.quotes("AAPL271217C00250000");
+  const q = quotes[0];
+  console.log(
+    `${q.optionSymbol}: bid=${q.bid} ask=${q.ask} delta=${q.delta}`
+  );
+} catch (error) {
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="app.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { OptionsQuotes } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const quotes: OptionsQuotes[] = await client.options.quotes("AAPL271217C00250000");
+  const q = quotes[0];
+  console.log(
+    `${q.optionSymbol}: bid=${q.bid} ask=${q.ask} delta=${q.delta}`
+  );
+} catch (error) {
+  console.error(error);
+}
 ```
 
 </TabItem>

--- a/api/stocks/bulkcandles.mdx
+++ b/api/stocks/bulkcandles.mdx
@@ -24,18 +24,49 @@ GET
 **GET** [https://api.marketdata.app/v1/stocks/bulkcandles/D/?symbols=AAPL,META,MSFT](https://api.marketdata.app/v1/stocks/bulkcandles/D/?symbols=AAPL,META,MSFT)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
+
+:::note
+The JavaScript/TypeScript SDK does not yet provide a method for the bulk candles endpoint, so these examples use the raw `fetch()` API. They will be replaced with `marketdata-sdk` examples once bulk support is added.
+:::
 
 ```js title="app.js"
 fetch(
   "https://api.marketdata.app/v1/stocks/bulkcandles/D/?symbols=AAPL,META,MSFT"
 )
-  .then((res) => {
-    console.log(res);
+  .then((res) => res.json())
+  .then((data) => {
+    console.log(data);
   })
   .catch((err) => {
     console.log(err);
   });
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+:::note
+The JavaScript/TypeScript SDK does not yet provide a method for the bulk candles endpoint, so these examples use the raw `fetch()` API. They will be replaced with `marketdata-sdk` examples once bulk support is added.
+:::
+
+```typescript title="app.ts"
+interface BulkCandlesResponse {
+  s: string;
+  symbol: string[];
+  o: number[];
+  h: number[];
+  l: number[];
+  c: number[];
+  v: number[];
+  t: number[];
+}
+
+const response: Response = await fetch(
+  "https://api.marketdata.app/v1/stocks/bulkcandles/D/?symbols=AAPL,META,MSFT"
+);
+const data: BulkCandlesResponse = await response.json();
+console.log(data);
 ```
 
 </TabItem>

--- a/api/stocks/candles.mdx
+++ b/api/stocks/candles.mdx
@@ -24,19 +24,42 @@ GET
 **GET** [https://api.marketdata.app/v1/stocks/candles/D/AAPL/?from=2020-01-01&to=2020-12-31](https://api.marketdata.app/v1/stocks/candles/D/AAPL/?from=2020-01-01&to=2020-12-31)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="app.js"
-fetch(
-  "https://api.marketdata.app/v1/stocks/candles/D/AAPL/?from=2020-01-01&to=2020-12-31"
-)
-  .then((res) => {
-    console.log(res);
-  })
-  .catch((err) => {
-    console.log(err);
-  });
+import { MarketDataClient } from "marketdata-sdk";
 
+const client = new MarketDataClient();
+
+try {
+  // Default resolution is "D" (daily)
+  const candles = await client.stocks.candles("AAPL", { countback: 30 });
+  for (const c of candles) {
+    console.log(`t=${c.t} o=${c.o} h=${c.h} l=${c.l} c=${c.c} v=${c.v}`);
+  }
+} catch (error) {
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="app.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { StockCandle } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  // Default resolution is "D" (daily)
+  const candles: StockCandle[] = await client.stocks.candles("AAPL", { countback: 30 });
+  for (const c of candles) {
+    console.log(`t=${c.t} o=${c.o} h=${c.h} l=${c.l} c=${c.c} v=${c.v}`);
+  }
+} catch (error) {
+  console.error(error);
+}
 ```
 
 </TabItem>

--- a/api/stocks/earnings.mdx
+++ b/api/stocks/earnings.mdx
@@ -29,16 +29,46 @@ GET
 **GET** [https://api.marketdata.app/v1/stocks/earnings/AAPL/](https://api.marketdata.app/v1/stocks/earnings/AAPL/)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="app.js"
-fetch("https://api.marketdata.app/v1/stocks/earnings/AAPL/")
-  .then((res) => {
-    console.log(res);
-  })
-  .catch((err) => {
-    console.log(err);
-  });
+import { MarketDataClient } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const earnings = await client.stocks.earnings("AAPL");
+  for (const e of earnings) {
+    console.log(
+      `FY${e.fiscalYear} Q${e.fiscalQuarter}: ` +
+      `reported=${e.reportedEPS} estimated=${e.estimatedEPS}`
+    );
+  }
+} catch (error) {
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="app.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { StockEarningsResponse } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const earnings: StockEarningsResponse = await client.stocks.earnings("AAPL");
+  for (const e of earnings) {
+    console.log(
+      `FY${e.fiscalYear} Q${e.fiscalQuarter}: ` +
+      `reported=${e.reportedEPS} estimated=${e.estimatedEPS}`
+    );
+  }
+} catch (error) {
+  console.error(error);
+}
 ```
 
 </TabItem>

--- a/api/stocks/news.mdx
+++ b/api/stocks/news.mdx
@@ -33,16 +33,40 @@ GET
 **GET** [https://api.marketdata.app/v1/stocks/news/AAPL/](https://api.marketdata.app/v1/stocks/news/AAPL/)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="app.js"
-fetch("https://api.marketdata.app/v1/stocks/news/AAPL/")
-  .then((res) => {
-    console.log(res);
-  })
-  .catch((err) => {
-    console.log(err);
-  });
+import { MarketDataClient } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const articles = await client.stocks.news("AAPL");
+  for (const a of articles) {
+    console.log(`${a.source}: ${a.headline}`);
+  }
+} catch (error) {
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="app.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { StockNews } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const articles: StockNews[] = await client.stocks.news("AAPL");
+  for (const a of articles) {
+    console.log(`${a.source}: ${a.headline}`);
+  }
+} catch (error) {
+  console.error(error);
+}
 ```
 
 </TabItem>

--- a/api/stocks/prices.mdx
+++ b/api/stocks/prices.mdx
@@ -36,16 +36,36 @@ GET
 **GET** [https://api.marketdata.app/v1/stocks/prices/AAPL/](https://api.marketdata.app/v1/stocks/prices/AAPL/)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="app.js"
-fetch("https://api.marketdata.app/v1/stocks/prices/AAPL/")
-  .then((res) => {
-    console.log(res);
-  })
-  .catch((err) => {
-    console.log(err);
-  });
+import { MarketDataClient } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const prices = await client.stocks.prices("AAPL");
+  console.log(prices[0].mid);
+} catch (error) {
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="app.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { StockPrice } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const prices: StockPrice[] = await client.stocks.prices("AAPL");
+  console.log(prices[0].mid);
+} catch (error) {
+  console.error(error);
+}
 ```
 
 </TabItem>
@@ -83,16 +103,40 @@ echo $prices;
 **GET** [https://api.marketdata.app/v1/stocks/prices/?symbols=AAPL,META,MSFT](https://api.marketdata.app/v1/stocks/prices/?symbols=AAPL,META,MSFT)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="app.js"
-fetch("https://api.marketdata.app/v1/stocks/prices/?symbols=AAPL,META,MSFT")
-  .then((res) => {
-    console.log(res);
-  })
-  .catch((err) => {
-    console.log(err);
-  });
+import { MarketDataClient } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const prices = await client.stocks.prices(["AAPL", "META", "MSFT"]);
+  for (const p of prices) {
+    console.log(`${p.symbol}: mid=${p.mid}`);
+  }
+} catch (error) {
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="app.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { StockPrice } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const prices: StockPrice[] = await client.stocks.prices(["AAPL", "META", "MSFT"]);
+  for (const p of prices) {
+    console.log(`${p.symbol}: mid=${p.mid}`);
+  }
+} catch (error) {
+  console.error(error);
+}
 ```
 
 </TabItem>

--- a/api/stocks/quotes.mdx
+++ b/api/stocks/quotes.mdx
@@ -32,16 +32,36 @@ GET
 **GET** [https://api.marketdata.app/v1/stocks/quotes/AAPL/](https://api.marketdata.app/v1/stocks/quotes/AAPL/)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="app.js"
-fetch("https://api.marketdata.app/v1/stocks/quotes/AAPL/")
-  .then((res) => {
-    console.log(res);
-  })
-  .catch((err) => {
-    console.log(err);
-  });
+import { MarketDataClient } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const quotes = await client.stocks.quotes("AAPL");
+  console.log(quotes);
+} catch (error) {
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="app.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { StockQuote } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const quotes: StockQuote[] = await client.stocks.quotes("AAPL");
+  console.log(quotes);
+} catch (error) {
+  console.error(error);
+}
 ```
 
 </TabItem>
@@ -102,16 +122,40 @@ echo $quote;
 **GET** [https://api.marketdata.app/v1/stocks/quotes/?symbols=AAPL,META,MSFT](https://api.marketdata.app/v1/stocks/quotes/?symbols=AAPL,META,MSFT)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="app.js"
-fetch("https://api.marketdata.app/v1/stocks/quotes/?symbols=AAPL,META,MSFT")
-  .then((res) => {
-    console.log(res);
-  })
-  .catch((err) => {
-    console.log(err);
-  });
+import { MarketDataClient } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const quotes = await client.stocks.quotes(["AAPL", "META", "MSFT"]);
+  for (const q of quotes) {
+    console.log(`${q.symbol}: bid=${q.bid}, ask=${q.ask}, last=${q.last}`);
+  }
+} catch (error) {
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="app.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { StockQuote } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const quotes: StockQuote[] = await client.stocks.quotes(["AAPL", "META", "MSFT"]);
+  for (const q of quotes) {
+    console.log(`${q.symbol}: bid=${q.bid}, ask=${q.ask}, last=${q.last}`);
+  }
+} catch (error) {
+  console.error(error);
+}
 ```
 
 </TabItem>

--- a/api/troubleshooting/logging.mdx
+++ b/api/troubleshooting/logging.mdx
@@ -19,29 +19,48 @@ When logging errors, the log should include the exact request made, Market Data'
 ## Logging Examples
 
 <Tabs>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="logger.js"
-const axios = require("axios");
-const fs = require("fs");
+import { MarketDataClient, DefaultLogger, LogLevel } from "marketdata-sdk";
 
-// Make the API request
-axios
-  .get("https://api.marketdata.app/v1/your_endpoint_here/")
-  .then((response) => {
-    // Do nothing for successful responses
-  })
-  .catch((error) => {
-    if (error.response.status !== 200 && error.response.status !== 203) {
-      const logData = {
-        request: error.config.method.toUpperCase() + " " + error.config.url,
-        response: error.response.data,
-        cfRayHeader: error.response.headers["cf-ray"] || "Not available",
-      };
-      // Save to a logfile
-      fs.appendFileSync("api_error_log.json", JSON.stringify(logData) + "\n");
-    }
-  });
+// Enable DEBUG-level logging to capture full request/response diagnostics
+// (including the CF-Ray header) for every API call.
+const client = new MarketDataClient({
+  logger: new DefaultLogger(LogLevel.DEBUG),
+});
+
+try {
+  const quotes = await client.stocks.quotes("AAPL");
+  console.log(quotes);
+} catch (error) {
+  // The SDK logs the failing request and response automatically;
+  // handle the error here as needed.
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="logger.ts"
+import { MarketDataClient, DefaultLogger, LogLevel } from "marketdata-sdk";
+import type { StockQuote } from "marketdata-sdk";
+
+// Enable DEBUG-level logging to capture full request/response diagnostics
+// (including the CF-Ray header) for every API call.
+const client = new MarketDataClient({
+  logger: new DefaultLogger(LogLevel.DEBUG),
+});
+
+try {
+  const quotes: StockQuote[] = await client.stocks.quotes("AAPL");
+  console.log(quotes);
+} catch (error) {
+  // The SDK logs the failing request and response automatically;
+  // handle the error here as needed.
+  console.error(error);
+}
 ```
 
 </TabItem>

--- a/api/troubleshooting/real-time-data.mdx
+++ b/api/troubleshooting/real-time-data.mdx
@@ -73,42 +73,81 @@ elif isinstance(quotes, dict) and quotes.get("s") == "ok" and "updated" in quote
 ```
 
 </TabItem>
-<TabItem value="NodeJS" label="Node.js">
+<TabItem value="JavaScript" label="JavaScript">
 
-```javascript
-const response = await fetch(
-  "https://api.marketdata.app/v1/stocks/quotes/AAPL/",
-  {
-    headers: {
-      "Authorization": "Bearer YOUR_TOKEN"
+```js title="checkDataAge.js"
+import { MarketDataClient, Mode } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  // Request live data, then inspect the `updated` timestamp.
+  const quotes = await client.stocks.quotes("AAPL", { mode: Mode.LIVE });
+  const quote = quotes[0];
+
+  if (quote?.updated) {
+    // `updated` is a Unix timestamp in seconds.
+    const updatedTime = new Date(quote.updated * 1000);
+    const currentTime = new Date();
+
+    // Calculate the age of the data
+    const ageMinutes = (currentTime - updatedTime) / 1000 / 60;
+
+    console.log(`Data timestamp: ${updatedTime}`);
+    console.log(`Current time: ${currentTime}`);
+    console.log(`Data age: ${ageMinutes.toFixed(1)} minutes`);
+
+    // Determine data type
+    if (ageMinutes < 1) {
+      console.log("✅ Real-time data (less than 1 minute old)");
+    } else if (ageMinutes < 20) {
+      console.log("⚠️ 15-minute delayed data");
+    } else {
+      console.log("❌ Historical data (1 day old or more)");
     }
   }
-);
+} catch (error) {
+  console.error(error);
+}
+```
 
-const data = await response.json();
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
 
-if (data.s === "ok" && data.updated) {
-  // Get the timestamp (Unix epoch seconds)
-  const updatedTimestamp = data.updated[0] * 1000; // Convert to milliseconds
-  const updatedTime = new Date(updatedTimestamp);
-  const currentTime = new Date();
-  
-  // Calculate the age of the data
-  const ageSeconds = (currentTime - updatedTime) / 1000;
-  const ageMinutes = ageSeconds / 60;
-  
-  console.log(`Data timestamp: ${updatedTime}`);
-  console.log(`Current time: ${currentTime}`);
-  console.log(`Data age: ${ageMinutes.toFixed(1)} minutes`);
-  
-  // Determine data type
-  if (ageMinutes < 1) {
-    console.log("✅ Real-time data (less than 1 minute old)");
-  } else if (ageMinutes < 20) {
-    console.log("⚠️ 15-minute delayed data");
-  } else {
-    console.log("❌ Historical data (1 day old or more)");
+```typescript title="checkDataAge.ts"
+import { MarketDataClient, Mode } from "marketdata-sdk";
+import type { StockQuote } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  // Request live data, then inspect the `updated` timestamp.
+  const quotes: StockQuote[] = await client.stocks.quotes("AAPL", { mode: Mode.LIVE });
+  const quote = quotes[0];
+
+  if (quote?.updated) {
+    // `updated` is a Unix timestamp in seconds.
+    const updatedTime = new Date(quote.updated * 1000);
+    const currentTime = new Date();
+
+    // Calculate the age of the data
+    const ageMinutes = (currentTime.getTime() - updatedTime.getTime()) / 1000 / 60;
+
+    console.log(`Data timestamp: ${updatedTime}`);
+    console.log(`Current time: ${currentTime}`);
+    console.log(`Data age: ${ageMinutes.toFixed(1)} minutes`);
+
+    // Determine data type
+    if (ageMinutes < 1) {
+      console.log("✅ Real-time data (less than 1 minute old)");
+    } else if (ageMinutes < 20) {
+      console.log("⚠️ 15-minute delayed data");
+    } else {
+      console.log("❌ Historical data (1 day old or more)");
+    }
   }
+} catch (error) {
+  console.error(error);
 }
 ```
 
@@ -342,56 +381,104 @@ test_realtime_data("AAPL")
 ```
 
 </TabItem>
-<TabItem value="NodeJS" label="Node.js">
+<TabItem value="JavaScript" label="JavaScript">
 
-```javascript
+```js title="testRealtimeData.js"
+import { MarketDataClient, Mode } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
 async function testRealtimeData(symbol = "AAPL") {
-  const response = await fetch(
-    `https://api.marketdata.app/v1/stocks/quotes/${symbol}/`,
-    {
-      headers: {
-        "Authorization": "Bearer YOUR_TOKEN"
-      }
+  try {
+    const quotes = await client.stocks.quotes(symbol, { mode: Mode.LIVE });
+    const quote = quotes[0];
+
+    if (!quote?.updated) {
+      console.log("Warning: No timestamp in response");
+      return false;
     }
-  );
-  
-  const data = await response.json();
-  
-  if (data.s !== "ok") {
-    console.log(`Error: ${data.errmsg || "Unknown error"}`);
+
+    // `updated` is a Unix timestamp in seconds.
+    const updatedTime = new Date(quote.updated * 1000);
+    const currentTime = new Date();
+
+    // Calculate age
+    const ageMinutes = (currentTime - updatedTime) / 1000 / 60;
+
+    console.log(`Symbol: ${symbol}`);
+    console.log(`Data timestamp: ${updatedTime.toISOString()}`);
+    console.log(`Current time: ${currentTime.toISOString()}`);
+    console.log(`Data age: ${ageMinutes.toFixed(2)} minutes`);
+
+    // Check if real-time (less than 1 minute old during market hours)
+    if (ageMinutes < 1) {
+      console.log("✅ Real-time data is working!");
+      return true;
+    } else if (ageMinutes < 20) {
+      console.log("⚠️ Receiving 15-minute delayed data");
+      console.log("   → Check if IEX agreement is signed and approved");
+      return false;
+    } else {
+      console.log("❌ Receiving historical data (1 day old)");
+      console.log("   → Check if profile is complete and agreements are signed");
+      return false;
+    }
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
     return false;
   }
-  
-  if (!data.updated) {
-    console.log("Warning: No timestamp in response");
-    return false;
-  }
-  
-  // Get timestamp
-  const updatedTimestamp = data.updated[0] * 1000; // Convert to milliseconds
-  const updatedTime = new Date(updatedTimestamp);
-  const currentTime = new Date();
-  
-  // Calculate age
-  const ageSeconds = (currentTime - updatedTime) / 1000;
-  const ageMinutes = ageSeconds / 60;
-  
-  console.log(`Symbol: ${symbol}`);
-  console.log(`Data timestamp: ${updatedTime.toISOString()}`);
-  console.log(`Current time: ${currentTime.toISOString()}`);
-  console.log(`Data age: ${ageMinutes.toFixed(2)} minutes`);
-  
-  // Check if real-time (less than 1 minute old during market hours)
-  if (ageMinutes < 1) {
-    console.log("✅ Real-time data is working!");
-    return true;
-  } else if (ageMinutes < 20) {
-    console.log("⚠️ Receiving 15-minute delayed data");
-    console.log("   → Check if IEX agreement is signed and approved");
-    return false;
-  } else {
-    console.log("❌ Receiving historical data (1 day old)");
-    console.log("   → Check if profile is complete and agreements are signed");
+}
+
+// Test during market hours for best results
+testRealtimeData("AAPL");
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="testRealtimeData.ts"
+import { MarketDataClient, Mode } from "marketdata-sdk";
+import type { StockQuote } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+async function testRealtimeData(symbol: string = "AAPL"): Promise<boolean> {
+  try {
+    const quotes: StockQuote[] = await client.stocks.quotes(symbol, { mode: Mode.LIVE });
+    const quote = quotes[0];
+
+    if (!quote?.updated) {
+      console.log("Warning: No timestamp in response");
+      return false;
+    }
+
+    // `updated` is a Unix timestamp in seconds.
+    const updatedTime = new Date(quote.updated * 1000);
+    const currentTime = new Date();
+
+    // Calculate age
+    const ageMinutes = (currentTime.getTime() - updatedTime.getTime()) / 1000 / 60;
+
+    console.log(`Symbol: ${symbol}`);
+    console.log(`Data timestamp: ${updatedTime.toISOString()}`);
+    console.log(`Current time: ${currentTime.toISOString()}`);
+    console.log(`Data age: ${ageMinutes.toFixed(2)} minutes`);
+
+    // Check if real-time (less than 1 minute old during market hours)
+    if (ageMinutes < 1) {
+      console.log("✅ Real-time data is working!");
+      return true;
+    } else if (ageMinutes < 20) {
+      console.log("⚠️ Receiving 15-minute delayed data");
+      console.log("   → Check if IEX agreement is signed and approved");
+      return false;
+    } else {
+      console.log("❌ Receiving historical data (1 day old)");
+      console.log("   → Check if profile is complete and agreements are signed");
+      return false;
+    }
+  } catch (error) {
+    console.error(`Error: ${(error as Error).message}`);
     return false;
   }
 }

--- a/api/troubleshooting/service-outages.mdx
+++ b/api/troubleshooting/service-outages.mdx
@@ -33,50 +33,74 @@ This endpoint is ideal to allow for automatic switching between Market Data and 
 :::
 
 <Tabs>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="status.js"
-// Importing the required library
-const axios = require('axios');
+import { MarketDataClient } from "marketdata-sdk";
 
-// URL to the status endpoint
-const url = "https://api.marketdata.app/status/";
+const client = new MarketDataClient();
 
-// Function to check the status of a specific endpoint
-async function checkEndpointStatus(endpointPath) {
-    try {
-        const response = await axios.get(url);
-        const jsonData = response.data;
-        const index = jsonData.service.indexOf(endpointPath);
-
-        if (index !== -1) {
-            return {
-                online: jsonData.online[index],
-                status: jsonData.status[index],
-                uptime30d: jsonData.uptimePct30d[index],
-                uptime90d: jsonData.uptimePct90d[index]
-            };
-        } else {
-            return null;
-        }
-    } catch (error) {
-        console.error("Error fetching API status:", error);
-        return null;
-    }
+// Look up the status of a specific endpoint in the API status response.
+function findEndpointStatus(status, endpointPath) {
+  const index = status.service.indexOf(endpointPath);
+  if (index === -1) return null;
+  return {
+    online: status.online[index],
+    status: status.status[index],
+    uptime30d: status.uptimePct30d?.[index],
+    uptime90d: status.uptimePct90d?.[index],
+  };
 }
 
-// Checking the status of specific endpoints
-async function checkStatuses() {
-    const stocksQuotes = await checkEndpointStatus("/v1/stocks/quotes/");
-    const optionsChain = await checkEndpointStatus("/v1/options/chain/");
-    const stocksCandles = await checkEndpointStatus("/v1/stocks/candles/");
+try {
+  const status = await client.utilities.status();
 
-    console.log(`Stocks Quotes: ${stocksQuotes ? (stocksQuotes.online ? "Online" : "Offline") : "Not found"}`);
-    console.log(`Options Chain: ${optionsChain ? (optionsChain.online ? "Online" : "Offline") : "Not found"}`);
-    console.log(`Stocks Candles: ${stocksCandles ? (stocksCandles.online ? "Online" : "Offline") : "Not found"}`);
+  const stocksQuotes = findEndpointStatus(status, "/v1/stocks/quotes/");
+  const optionsChain = findEndpointStatus(status, "/v1/options/chain/");
+  const stocksCandles = findEndpointStatus(status, "/v1/stocks/candles/");
+
+  console.log(`Stocks Quotes: ${stocksQuotes ? (stocksQuotes.online ? "Online" : "Offline") : "Not found"}`);
+  console.log(`Options Chain: ${optionsChain ? (optionsChain.online ? "Online" : "Offline") : "Not found"}`);
+  console.log(`Stocks Candles: ${stocksCandles ? (stocksCandles.online ? "Online" : "Offline") : "Not found"}`);
+} catch (error) {
+  console.error("Error fetching API status:", error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="status.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { ApiStatusResponse } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+// Look up the status of a specific endpoint in the API status response.
+function findEndpointStatus(status: ApiStatusResponse, endpointPath: string) {
+  const index = status.service.indexOf(endpointPath);
+  if (index === -1) return null;
+  return {
+    online: status.online[index],
+    status: status.status[index],
+    uptime30d: status.uptimePct30d?.[index],
+    uptime90d: status.uptimePct90d?.[index],
+  };
 }
 
-checkStatuses();
+try {
+  const status: ApiStatusResponse = await client.utilities.status();
+
+  const stocksQuotes = findEndpointStatus(status, "/v1/stocks/quotes/");
+  const optionsChain = findEndpointStatus(status, "/v1/options/chain/");
+  const stocksCandles = findEndpointStatus(status, "/v1/stocks/candles/");
+
+  console.log(`Stocks Quotes: ${stocksQuotes ? (stocksQuotes.online ? "Online" : "Offline") : "Not found"}`);
+  console.log(`Options Chain: ${optionsChain ? (optionsChain.online ? "Online" : "Offline") : "Not found"}`);
+  console.log(`Stocks Candles: ${stocksCandles ? (stocksCandles.online ? "Online" : "Offline") : "Not found"}`);
+} catch (error) {
+  console.error("Error fetching API status:", error);
+}
 ```
 
 </TabItem>

--- a/api/utilities/headers.mdx
+++ b/api/utilities/headers.mdx
@@ -29,13 +29,38 @@ GET
 **GET** [https://api.marketdata.app/headers/](https://api.marketdata.app/headers/)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="headersCheck.js"
-fetch("https://api.marketdata.app/headers/")
-  .then((res) => res.json())
-  .then((json) => console.log(json))
-  .catch((err) => console.log(err));
+import { MarketDataClient } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const h = await client.utilities.headers();
+  console.log(h["user-agent"]);
+  console.log(h["accept-encoding"]);
+} catch (error) {
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="headersCheck.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { HeadersResponse } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const h: HeadersResponse = await client.utilities.headers();
+  console.log(h["user-agent"]);
+  console.log(h["accept-encoding"]);
+} catch (error) {
+  console.error(error);
+}
 ```
 
 </TabItem>

--- a/api/utilities/status.mdx
+++ b/api/utilities/status.mdx
@@ -31,13 +31,40 @@ GET
 **GET** [https://api.marketdata.app/status/](https://api.marketdata.app/status/)
 
 </TabItem>
-<TabItem value="NodeJS" label="NodeJS">
+<TabItem value="JavaScript" label="JavaScript">
 
 ```js title="statusCheck.js"
-fetch("https://api.marketdata.app/status/")
-  .then((res) => res.json())
-  .then((json) => console.log(json))
-  .catch((err) => console.log(err));
+import { MarketDataClient } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const s = await client.utilities.status();
+  for (let i = 0; i < s.service.length; i++) {
+    console.log(`${s.service[i]}: ${s.status[i]} (online=${s.online[i]})`);
+  }
+} catch (error) {
+  console.error(error);
+}
+```
+
+</TabItem>
+<TabItem value="TypeScript" label="TypeScript">
+
+```typescript title="statusCheck.ts"
+import { MarketDataClient } from "marketdata-sdk";
+import type { ApiStatusResponse } from "marketdata-sdk";
+
+const client = new MarketDataClient();
+
+try {
+  const s: ApiStatusResponse = await client.utilities.status();
+  for (let i = 0; i < s.service.length; i++) {
+    console.log(`${s.service[i]}: ${s.status[i]} (online=${s.online[i]})`);
+  }
+} catch (error) {
+  console.error(error);
+}
 ```
 
 </TabItem>


### PR DESCRIPTION
Bring the JS examples across the API reference in line with the other languages now that the JavaScript/TypeScript SDK (marketdata-sdk) is shipped. Each affected page's single NodeJS raw-fetch tab is replaced with paired JavaScript and TypeScript tabs using the SDK (await + try/catch), sourced from the matching sdk/js/* page.

- 13 endpoint pages: 1:1 SDK swap (stocks/{quotes,prices,candles, earnings,news}, options/{chain,expirations,lookup,quotes}, funds/candles, markets/status, utilities/{status,headers}).
- authentication.mdx: env-var + explicit-token forms.
- troubleshooting/logging.mdx: SDK DefaultLogger(LogLevel.DEBUG).
- troubleshooting/real-time-data.mdx: client.stocks.quotes + Mode.LIVE, keeping the data-age diagnostic logic.
- troubleshooting/service-outages.mdx: client.utilities.status().
- stocks/bulkcandles.mdx: SDK has no bulk method yet, so JavaScript keeps raw fetch() and TypeScript uses the typed Response API; a note documents this until bulk support lands.

Closes #151