### PR TITLE
Add Kotlin logo and reorder SDKs by market-data popularity

### DIFF
--- a/sdk/go/index.mdx
+++ b/sdk/go/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Go SDK
-sidebar_position: 5
+sidebar_position: 6
 slug: /go
 ---
 

--- a/sdk/index.mdx
+++ b/sdk/index.mdx
@@ -31,9 +31,9 @@ Our SDKs are available for a multitude of programming languages and platforms, s
   </div>
 
   <div className="sdk-item">
-    [![PHP SDK Logo](/img/php-logo.svg)](/sdk/php)
-    ### [PHP SDK](/sdk/php)
-    [Market Data integration for web applications and server-side processing.](/sdk/php)
+    [![Java Logo](/img/java-logo.svg)![Kotlin Logo](/img/kotlin-logo.svg)](/sdk/java)
+    ### [Java / Kotlin SDK](/sdk/java)
+    [Typed Market Data integration for JVM applications, with first-class Kotlin interop.](/sdk/java)
   </div>
 
   <div className="sdk-item">
@@ -43,9 +43,9 @@ Our SDKs are available for a multitude of programming languages and platforms, s
   </div>
 
   <div className="sdk-item">
-    [![Java Logo](/img/java-logo.svg)![Kotlin Logo](/img/kotlin-logo.svg)](/sdk/java)
-    ### [Java / Kotlin SDK](/sdk/java)
-    [Typed Market Data integration for JVM applications, with first-class Kotlin interop.](/sdk/java)
+    [![PHP SDK Logo](/img/php-logo.svg)](/sdk/php)
+    ### [PHP SDK](/sdk/php)
+    [Market Data integration for web applications and server-side processing.](/sdk/php)
   </div>
 
 </div>

--- a/sdk/index.mdx
+++ b/sdk/index.mdx
@@ -43,8 +43,8 @@ Our SDKs are available for a multitude of programming languages and platforms, s
   </div>
 
   <div className="sdk-item">
-    [![Java SDK Logo](/img/java-logo.svg)](/sdk/java)
-    ### [Java SDK](/sdk/java)
+    [![Java Logo](/img/java-logo.svg)![Kotlin Logo](/img/kotlin-logo.svg)](/sdk/java)
+    ### [Java / Kotlin SDK](/sdk/java)
     [Typed Market Data integration for JVM applications, with first-class Kotlin interop.](/sdk/java)
   </div>
 

--- a/sdk/java/index.mdx
+++ b/sdk/java/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Java SDK
-sidebar_position: 6
+sidebar_position: 5
 slug: /java
 sidebar_custom_props:
   badge: n

--- a/sdk/php/index.mdx
+++ b/sdk/php/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: PHP SDK
-sidebar_position: 4
+sidebar_position: 7
 slug: /php
 ---
 

--- a/static/img/kotlin-logo.svg
+++ b/static/img/kotlin-logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="kotlin-a" x1="500.003" x2="-.097" y1="579.106" y2="1079.206" gradientTransform="translate(15.534 -96.774) scale(.1939)" gradientUnits="userSpaceOnUse">
+      <stop offset=".003" stop-color="#e44857"/>
+      <stop offset=".469" stop-color="#c711e1"/>
+      <stop offset="1" stop-color="#7f52ff"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#kotlin-a)" d="M112.484 112.484H15.516V15.516h96.968L64 64Zm0 0"/>
+</svg>


### PR DESCRIPTION
## Summary

- **Kotlin logo on SDK index** — the Java SDK card now shows both the Java and Kotlin logos (mirroring the JS/TS dual-logo treatment) and is titled "Java / Kotlin SDK", reflecting the SDK's first-class Kotlin interop
- **SDK ordering by market-data popularity** — both the picker cards (`sdk/index.mdx`) and the autogenerated sidebar (`sidebar_position`) now order: Postman → Python → JavaScript/TypeScript → Java/Kotlin → Go → PHP. Also fixes a prior `sidebar_position` tie between JS and PHP (both were 4).

## Test plan

- [ ] Verify the SDK index picker shows Java + Kotlin logos side by side and the new order at www-staging.marketdata.app/docs/sdk/
- [ ] Verify the sidebar reflects the same order
- [ ] CI checks green on staging