### PR TITLE
fix(sdk-java): correct install version from 0.1.0 to 1.0.0

### DIFF
--- a/sdk/java/installation.mdx
+++ b/sdk/java/installation.mdx
@@ -23,7 +23,7 @@ Add the SDK as a dependency. The published artifact is a single JAR; it does **n
 ```kotlin
 // build.gradle.kts
 dependencies {
-    implementation("app.marketdata:marketdata-sdk-java:0.1.0")
+    implementation("app.marketdata:marketdata-sdk-java:1.0.0")
 }
 ```
 
@@ -33,7 +33,7 @@ dependencies {
 ```groovy
 // build.gradle
 dependencies {
-    implementation 'app.marketdata:marketdata-sdk-java:0.1.0'
+    implementation 'app.marketdata:marketdata-sdk-java:1.0.0'
 }
 ```
 
@@ -44,7 +44,7 @@ dependencies {
 <dependency>
   <groupId>app.marketdata</groupId>
   <artifactId>marketdata-sdk-java</artifactId>
-  <version>0.1.0</version>
+  <version>1.0.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Corrects the Java SDK install snippets (Gradle Kotlin/Groovy, Maven) to reference version `1.0.0` instead of the stale `0.1.0`. Verified against the SDK's build.gradle.kts.