### PR TITLE
fix(docs): repair 14 broken links and add a broken-link PR check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,6 +17,24 @@ jobs:
       - name: Check markdown table alignment
         run: node scripts/fix-table-alignment.js
 
+  broken-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+
+      # Builds with onBrokenLinks/onBrokenMarkdownLinks set to "throw". Deploys
+      # build with "warn" so a bad link cannot block a release, which means this
+      # PR check is the gate that keeps broken links off the site.
+      - name: Check for broken links
+        run: yarn lint:links
+
   worker-unit-tests:
     runs-on: ubuntu-latest
     steps:

--- a/account/data-freshness.md
+++ b/account/data-freshness.md
@@ -24,10 +24,10 @@ If you query an options endpoint at 6:33 AM ET Wednesday on a plan that provides
 
 ## By Plan
 
-The tables below show the freshness category for every API endpoint, by plan, and assume non-professional status. Real-time exchange data is never available to professional subscribers — see the [Notes](#notes) below. For the underlying entitlement model, see [Exchange Entitlements](./entitlements).
+The tables below show the freshness category for every API endpoint, by plan, and assume non-professional status. Real-time exchange data is never available to professional subscribers — see the [Notes](#notes) below. For the underlying entitlement model, see [Exchange Entitlements](/account/entitlements).
 
 :::info Real-time stock pricing comes from `/v1/stocks/prices/`
-[`/v1/stocks/prices/`](../api/stocks/prices) delivers Real-time stock prices with no delay on every paid plan. `/v1/stocks/quotes/`, `/v1/stocks/candles/`, and `/v1/stocks/bulkcandles/` carry the standard 15-minute exchange delay. Point your application at `/v1/stocks/prices/` when you need the current price.
+[`/v1/stocks/prices/`](/api/stocks/prices) delivers Real-time stock prices with no delay on every paid plan. `/v1/stocks/quotes/`, `/v1/stocks/candles/`, and `/v1/stocks/bulkcandles/` carry the standard 15-minute exchange delay. Point your application at `/v1/stocks/prices/` when you need the current price.
 :::
 
 ### Free Forever
@@ -158,6 +158,6 @@ Same freshness profile as Trader and Quant.
 
 ## Notes
 
-- **Real-time data and professional status:** Real-time exchange data is only available to non-professional subscribers. Professional subscribers **never** receive Real-time exchange data, no matter which exchange agreements they sign. Signing an agreement does not change this, and no self-service plan changes it. Delayed / historical data access remains available, depending on the data policies of each exchange. Real-time exchange data for professional use requires direct exchange licensing — [contact our sales team](https://www.marketdata.app/contact/) to discuss it. See [Professional Status Policy](/docs/account/data-policies/professional-status/), [Exchange Entitlements](./entitlements), and [Professional Status Explained](https://www.marketdata.app/education/stocks/professional-status-explained/).
-- **`/v1/funds/*` freshness** is documented per fund-data type and is pending publication here. Until then, refer to the individual endpoint pages under [Funds API](../api/funds/).
-- **Stock quotes and candles carry the 15-minute exchange delay.** `/v1/stocks/quotes/`, `/v1/stocks/candles/`, and `/v1/stocks/bulkcandles/` are delayed 15 minutes on every plan under the [UTP entitlement](./entitlements#utp-entitlement). The delay comes from the exchange, so `mode=live` does not shorten it — see [Data Mode](../api/universal-parameters/mode).
+- **Real-time data and professional status:** Real-time exchange data is only available to non-professional subscribers. Professional subscribers **never** receive Real-time exchange data, no matter which exchange agreements they sign. Signing an agreement does not change this, and no self-service plan changes it. Delayed / historical data access remains available, depending on the data policies of each exchange. Real-time exchange data for professional use requires direct exchange licensing — [contact our sales team](https://www.marketdata.app/contact/) to discuss it. See [Professional Status Policy](/docs/account/data-policies/professional-status/), [Exchange Entitlements](/account/entitlements), and [Professional Status Explained](https://www.marketdata.app/education/stocks/professional-status-explained/).
+- **`/v1/funds/*` freshness** is documented per fund-data type and is pending publication here. Until then, refer to the individual endpoint pages under [Funds API](/api/funds/).
+- **Stock quotes and candles carry the 15-minute exchange delay.** `/v1/stocks/quotes/`, `/v1/stocks/candles/`, and `/v1/stocks/bulkcandles/` are delayed 15 minutes on every plan under the [UTP entitlement](/account/entitlements#utp-entitlement). The delay comes from the exchange, so `mode=live` does not shorten it — see [Data Mode](/api/universal-parameters/mode).

--- a/account/plan-limits.md
+++ b/account/plan-limits.md
@@ -16,7 +16,7 @@ Each Market Data plan comes with certain limitations to allow for shared use of 
 | Options Data Type  | Delayed      | 15-minute delayed | Real-time   | Real-time        | Real-time        |
 | API Endpoints      | Standard     | Premium           | Premium     | Premium + Custom | Premium + Custom |
 
-\* See [Data Freshness](./data-freshness) for endpoint-level freshness.
+\* See [Data Freshness](/account/data-freshness) for endpoint-level freshness.
 
 ## Credits
 Each time you call the API, the system increases your credits counter. Normally each successful response consumes 1 credit. However, **if you request multiple symbols in a single API call using `stocks/quotes`, `stocks/prices`, `stocks/bulkcandles`, or `options/chain`, each symbol included in the response consumes credits**.
@@ -53,7 +53,7 @@ Free Forever accounts can access up to 1 year of historical data and Starter acc
 Free trials of paid plans provide delayed data. Real-time data is only available with paid versions of the Trader plan and above.
 :::
 
-For endpoint-level freshness rules and the Delayed → Historical rollover timing — including why options data only rolls at 9:30 AM ET the next trading day rather than at the prior session's close — see [Data Freshness](./data-freshness).
+For endpoint-level freshness rules and the Delayed → Historical rollover timing — including why options data only rolls at 9:30 AM ET the next trading day rather than at the prior session's close — see [Data Freshness](/account/data-freshness).
 
 ## API Endpoints
 

--- a/account/plans/commercial.mdx
+++ b/account/plans/commercial.mdx
@@ -46,7 +46,7 @@ The Commercial Plan is the entry point for businesses bringing a product to mark
 
 Most businesses start here when launching and add exchange licensing later, as their product matures and their budget grows.
 
-If you're an indie developer **still in development** and not yet charging users or distributing data, you can build on the [Starter Plan](starter) until you're ready to launch. Once you go live with a commercial product, the Commercial Plan is your next step. See our guide on [how stock market data licensing works](https://www.marketdata.app/education/stocks/stock-market-data-licensing) for background.
+If you're an indie developer **still in development** and not yet charging users or distributing data, you can build on the [Starter Plan](/account/plans/starter) until you're ready to launch. Once you go live with a commercial product, the Commercial Plan is your next step. See our guide on [how stock market data licensing works](https://www.marketdata.app/education/stocks/stock-market-data-licensing) for background.
 
 ### Not Suitable for Trading
 

--- a/account/plans/starter-trial.md
+++ b/account/plans/starter-trial.md
@@ -9,7 +9,7 @@ Market Data is excited to offer a **30-day free trial** of our Starter Plan, no 
 
 **$0 for 30 days** — no credit card required. The trial is strictly limited to 30 days and **cannot be renewed or extended**.
 
-Because no credit card is required to start the trial, **you will never be auto-billed when it ends**. If you take no action, your account automatically converts to the [Free Forever Plan](./free-forever) at the end of the 30 days. To keep premium features, you can subscribe to the [Starter Plan](./starter) for $12/month (billed annually) or $30/month at any time.
+Because no credit card is required to start the trial, **you will never be auto-billed when it ends**. If you take no action, your account automatically converts to the [Free Forever Plan](/account/plans/free-forever) at the end of the 30 days. To keep premium features, you can subscribe to the [Starter Plan](/account/plans/starter) for $12/month (billed annually) or $30/month at any time.
 
 ## What You Get with the Starter Trial Plan
 

--- a/account/plans/trader-trial.md
+++ b/account/plans/trader-trial.md
@@ -9,7 +9,7 @@ Market Data is thrilled to introduce a **30-day free trial** of our Trader Plan,
 
 **$0 for 30 days** — no credit card required. The trial is strictly limited to 30 days and **cannot be renewed or extended**.
 
-Because no credit card is required to start the trial, **you will never be auto-billed when it ends**. If you take no action, your account automatically converts to the [Free Forever Plan](./free-forever) at the end of the 30 days. To keep premium features, you can subscribe to the [Trader Plan](./trader) for $30/month (billed annually) or $75/month at any time.
+Because no credit card is required to start the trial, **you will never be auto-billed when it ends**. If you take no action, your account automatically converts to the [Free Forever Plan](/account/plans/free-forever) at the end of the 30 days. To keep premium features, you can subscribe to the [Trader Plan](/account/plans/trader) for $30/month (billed annually) or $75/month at any time.
 
 ## What You Get with the Trader Trial
 

--- a/api/authentication.mdx
+++ b/api/authentication.mdx
@@ -9,7 +9,7 @@ import TabItem from "@theme/TabItem";
 The Market Data API uses a **Bearer Token** for authentication. The token is a programmatic representation of your username and password credentials, so you must keep it secret just as you would your username and password. The token is required for each request you make to the API.
 
 :::caution Accept HTTP 203 as success
-Any endpoint may return HTTP `203 Non-Authoritative Information` instead of `200 OK` when the response is served from our caching tier. The body is identical in shape — treat 203 exactly the same as 200. Code samples below that use raw HTTP libraries (rather than our SDKs) must accept both status codes; checking only `status == 200` will silently drop valid responses. See [Troubleshooting](/troubleshooting) for the full list of status codes.
+Any endpoint may return HTTP `203 Non-Authoritative Information` instead of `200 OK` when the response is served from our caching tier. The body is identical in shape — treat 203 exactly the same as 200. Code samples below that use raw HTTP libraries (rather than our SDKs) must accept both status codes; checking only `status == 200` will silently drop valid responses. See [Troubleshooting](/api/troubleshooting) for the full list of status codes.
 :::
 
 ## Obtaining a Token

--- a/api/index.md
+++ b/api/index.md
@@ -13,7 +13,7 @@ https://api.marketdata.app/
 :::caution Accept HTTP 203 as success
 Any endpoint may return HTTP `203 Non-Authoritative Information` instead of `200 OK` when the response is served from our caching tier. This is normal — the body is identical in shape, and you should treat 203 exactly the same as 200. Many HTTP clients (and many OpenAPI-generated SDKs) default to treating only 200 as success; you must update your client to also accept 203 or your integration will silently fail in production.
 
-A `204 No Content` response can also occur when `mode=cached` is requested and no cached data is available — see [Data Mode](/api/universal-parameters/mode) and [Troubleshooting](/troubleshooting) for the full list of status codes.
+A `204 No Content` response can also occur when `mode=cached` is requested and no cached data is available — see [Data Mode](/api/universal-parameters/mode) and [Troubleshooting](/api/troubleshooting) for the full list of status codes.
 :::
 
 ## Try Our API

--- a/api/universal-parameters/mode.md
+++ b/api/universal-parameters/mode.md
@@ -189,4 +189,4 @@ A few notes on the retry pattern:
 - Cap the retry at one attempt. A subsequent `204` should not occur on `mode=live`, but a circuit breaker is still wise.
 - If your plan does not include `mode=cached` access (Free/Trial), `mode=cached` requests return `402 Payment Required` rather than `204`. See [402: Payment Required](/api/troubleshooting/payment-required).
 
-For the full list of HTTP status codes returned by the API (including `4xx` and `5xx`), see [Troubleshooting](/troubleshooting).
+For the full list of HTTP status codes returned by the API (including `4xx` and `5xx`), see [Troubleshooting](/api/troubleshooting).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -20,8 +20,12 @@ const config = {
   baseUrl: "/docs/",
   trailingSlash: true,
   noIndex: process.env.PROD !== "true",
-  onBrokenLinks: "ignore",
-  onBrokenMarkdownLinks: "warn",
+  // "warn" on deploys so a stray link never blocks a production release, but
+  // "throw" under STRICT_LINKS so the PR check (yarn lint:links) fails instead
+  // of letting broken links reach the site. This was "ignore" and silently
+  // accumulated 14 broken links.
+  onBrokenLinks: process.env.STRICT_LINKS === "true" ? "throw" : "warn",
+  onBrokenMarkdownLinks: process.env.STRICT_LINKS === "true" ? "throw" : "warn",
   favicon: "img/favicon.ico",
 
   organizationName: "marketdata",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "generate-docs": "node scripts/generate-master-docs.js",
     "export-sdk-docs": "node scripts/export-sdk-docs.js",
     "test:lib": "node --test lib/__tests__/*.test.js",
+    "lint:links": "STRICT_LINKS=true yarn build",
     "lint:tables": "node scripts/fix-table-alignment.js",
     "fix:tables": "node scripts/fix-table-alignment.js --fix",
     "test:e2e": "playwright test"

--- a/sdk/sdk-requirements.md
+++ b/sdk/sdk-requirements.md
@@ -147,7 +147,7 @@ Do not duplicate REST paths, payload schemas, or parameter contracts in this doc
 
 ### 2.1 Canonical API Documentation
 
-- [API Overview](/api/intro)
+- [API Overview](/api)
 - [Stocks API](/api/stocks/index)
 - [Options API](/api/options/index)
 - [Funds API](/api/funds/index)


### PR DESCRIPTION
The prices endpoint link on [Data Freshness](https://www.marketdata.app/docs/account/data-freshness/) 404'd. Investigating it turned up 13 more.

## Root cause

Two compounding problems:

1. **Extensionless relative links are not resolved at build time.** `[x](./entitlements)` is left as a raw relative href and resolved by the browser against the current URL, producing `/docs/account/data-freshness/entitlements/`. Links written as `[x](../data-freshness.md)` — with the extension — resolve correctly, which is why some links on the same page worked and others did not.
2. **Relative traversal cannot cross Docusaurus plugin instances.** `account` and `api` are separate `plugin-content-docs` instances, so `../api/stocks/prices` from an account page stays inside the account namespace and yields `/docs/account/api/stocks/prices/`.

Neither was caught because `onBrokenLinks` was set to `"ignore"`, which switches off Docusaurus's built-in detector entirely.

## Links fixed

All rewritten as absolute, baseUrl-prefixed paths.

| Page | Was | Now |
|---|---|---|
| `account/data-freshness` | `../api/stocks/prices` | `/api/stocks/prices` |
| `account/data-freshness` | `../api/funds/` | `/api/funds/` |
| `account/data-freshness` | `../api/universal-parameters/mode` | `/api/universal-parameters/mode` |
| `account/data-freshness` | `./entitlements` (x2, one with anchor) | `/account/entitlements` |
| `account/plan-limits` | `./data-freshness` | `/account/data-freshness` |
| `account/plans/starter-trial` | `./free-forever`, `./starter` | `/account/plans/...` |
| `account/plans/trader-trial` | `./free-forever`, `./trader` | `/account/plans/...` |
| `account/plans/commercial` | `starter` | `/account/plans/starter` |
| `api/index`, `api/authentication`, `api/universal-parameters/mode` | `/troubleshooting` | `/api/troubleshooting` |
| `sdk/sdk-requirements` | `/api/intro` | `/api` |

## Detection, so this cannot recur

- `onBrokenLinks` / `onBrokenMarkdownLinks` are now `"throw"` under `STRICT_LINKS=true` and `"warn"` otherwise. Deploys stay on `"warn"` so a stray link can never block a production release; the PR check is the gate.
- New `yarn lint:links` script.
- New `broken-links` job in PR checks. The existing PR checks never built the site, so a build-time setting alone would only have failed at deploy time.

## Verification

`yarn lint:links` passes with zero broken links on this branch. Built HTML confirms the five links on the Data Freshness page now emit `/docs/api/stocks/prices/`, `/docs/api/funds/`, `/docs/api/universal-parameters/mode/`, and `/docs/account/entitlements/`.