### PR TITLE
docs(api): Greeks are null on historical options requests; delta cannot be combined with date

### DIFF
--- a/api/options/chain.mdx
+++ b/api/options/chain.mdx
@@ -184,6 +184,10 @@ MarketDataClient().use { client ->
 
   Use to lookup a historical end of day options chain from a specific trading day. If no date parameter is specified the chain will be the most current chain available during market hours. When the market is closed the chain will be from the previous session. Accepted date inputs: `ISO 8601`, `unix`, `spreadsheet`.
 
+  :::info Historical chains carry no Greeks
+  Greeks and implied volatility are not stored historically. On any request that includes `date`, the `iv`, `delta`, `gamma`, `theta` and `vega` columns are returned as `null`, on every plan. For the same reason the `delta` filter cannot be combined with `date` (the request is rejected with `400`); filter historical chains by `strike` instead.
+  :::
+
 </TabItem>
 
 <TabItem value="expiration" label="Expiration Filters">
@@ -255,6 +259,10 @@ When combining the `weekly`, `monthly`, and `quarterly` parameters, only identic
 
   :::tip
   Filter strikes using the absolute value of the delta. The values used will always return both sides of the chain (e.g. puts & calls). This means you must filter using `side` to exclude puts or calls. Delta cannot be used to filter the side of the chain, only the strikes.
+  :::
+
+  :::caution Not available on historical requests
+  `delta` cannot be combined with the `date` parameter. Greeks are not stored historically, so there is no delta to filter on; such a request is rejected with `400 Bad Request` and the error message `The 'delta' parameter cannot be used with historical requests, because Greeks are not stored historically. Remove 'delta' from your request and filter by 'strike' instead.` Use the `strike` filter for historical chains.
   :::
 
 - **strikeLimit** `number`
@@ -422,6 +430,10 @@ The `am` and `pm` parameters are only applicable for index options such as SPX, 
 - **updated** `array[number]`
 
   The date and time of this quote snapshot. All timestamps use US Eastern Time (America/New_York). See [Response Timezone](/docs/api/dates-and-times#response-timezone) for details.
+
+:::note Greeks on historical requests
+`iv`, `delta`, `gamma`, `theta` and `vega` are only populated on current (real-time, delayed or end-of-day) chains. On any request that includes the `date` parameter these columns are returned as `null`, on every plan, because Greeks and implied volatility are not stored historically.
+:::
 
 - **iv** `array[number]`
 

--- a/api/options/quotes.mdx
+++ b/api/options/quotes.mdx
@@ -182,6 +182,10 @@ MarketDataClient().use { client ->
 
   Use to lookup a historical end of day quote from a specific trading day. If no date is specified the quote will be the most current price available during market hours. When the market is closed the quote will be from the last trading day. Accepted date inputs: `ISO 8601`, `unix`, `spreadsheet`.
 
+  :::info Historical quotes carry no Greeks
+  Greeks and implied volatility are not stored historically. On any request that includes `date`, `from` or `to`, the `iv`, `delta`, `gamma`, `theta` and `vega` columns are returned as `null`, on every plan.
+  :::
+
 - **from** `date`
 
   Use to lookup a series of end of day quotes. From is the oldest (leftmost) date to return (inclusive). If from/to is not specified the quote will be the most current price available during market hours. When the market is closed the quote will be from the last trading day. Accepted date inputs: `ISO 8601`, `unix`, `spreadsheet`.
@@ -257,6 +261,10 @@ MarketDataClient().use { client ->
 - **updated** `array[number]`
 
   The date and time of this quote snapshot. All timestamps use US Eastern Time (America/New_York). See [Response Timezone](/docs/api/dates-and-times#response-timezone) for details.
+
+:::note Greeks on historical requests
+`iv`, `delta`, `gamma`, `theta` and `vega` are only populated on current (real-time, delayed or end-of-day) quotes. On any request that includes `date`, `from` or `to` these columns are returned as `null`, on every plan, because Greeks and implied volatility are not stored historically.
+:::
 
 - **iv** `array[number]`
 


### PR DESCRIPTION
## Why

Several customers had to discover empirically that `iv`, `delta`, `gamma`, `theta`
and `vega` come back `null` on any options request carrying `date` (chain) or
`date`/`from`/`to` (quotes), on every plan, because Greeks are not stored
historically. Neither `chain.mdx` nor `quotes.mdx` said so
(helpdesk FCQ-154431, EQZ-900725, KJB-319572, DGW-774196).

The same gap hid a silent failure on the chain endpoint: the `delta` filter was
accepted and dropped on `date=` requests (MarketData-App/api#324). The API now
rejects that combination with `400`, so the docs must state the rule and the
exact error message.

## What changed

- `api/options/chain.mdx`
  - `date` parameter: info admonition, Greeks/IV are `null` on historical chains
    and `delta` cannot be combined with `date`.
  - `delta` parameter: caution admonition with the rule, the `400` and the exact
    `errmsg`, pointing to `strike` for historical chains.
  - Response tab: note above the Greek fields.
- `api/options/quotes.mdx`
  - `date` parameter: info admonition covering `date`, `from` and `to`.
  - Response tab: note above the Greek fields.

No SDK or example changes.

Related: MarketData-App/api#324. The `400` wording describes the behaviour after
the API fix, so this should be merged together with it or right after it lands;
the "Greeks are null on historical requests" notes are true today.
