### PR TITLE
docs(sdk): rename the C# package to marketdata.sdk and move to RC wording

### DIFF
--- a/sdk/csharp/index.mdx
+++ b/sdk/csharp/index.mdx
@@ -10,8 +10,8 @@ Welcome to the Market Data C#/.NET SDK documentation. This SDK lets you integrat
 
 The SDK multi-targets **.NET 8 and .NET 10** (both LTS), integrates with `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.Logging`, and dependency injection out of the box, and works equally well from a console app, a background service, or ASP.NET Core.
 
-:::warning Alpha
-The C#/.NET SDK is in **alpha**: it has not had a stable release and its public API may change without notice. NuGet packages are pre-release until a stable `v1.0.0` is tagged.
+:::info Release candidate
+The C#/.NET SDK is a **release candidate**: the public API is feature-complete and no breaking changes are planned before `v1.0.0`. NuGet packages stay pre-release (`1.0.0-rc.N`) until `v1.0.0` is tagged, so installing needs the `--prerelease` flag.
 :::
 
 ## Quick Start

--- a/sdk/csharp/installation.mdx
+++ b/sdk/csharp/installation.mdx
@@ -15,22 +15,22 @@ This guide will help you install the Market Data C#/.NET SDK and configure it fo
 Add the SDK as a NuGet package reference. From your project directory:
 
 ```bash
-dotnet add package MarketDataApp --prerelease
+dotnet add package marketdata.sdk --prerelease
 ```
 
-`dotnet add package` resolves the newest version for you and writes it into your project file. While the SDK is in alpha every published version is a pre-release, so the `--prerelease` flag is required (in an IDE, tick "Include prerelease" in the package manager).
+`dotnet add package` resolves the newest version for you and writes it into your project file. While the SDK is a release candidate every published version is a pre-release, so the `--prerelease` flag is required (in an IDE, tick "Include prerelease" in the package manager).
 
-If you maintain the reference by hand, take the version number from the package's [NuGet page](https://www.nuget.org/packages/MarketDataApp) or the [releases list](https://github.com/MarketDataApp/sdk-csharp/releases) — versions are derived from git tags, so there is no fixed number to copy from the docs:
+If you maintain the reference by hand, take the version number from the package's [NuGet page](https://www.nuget.org/packages/marketdata.sdk) or the [releases list](https://github.com/MarketDataApp/sdk-csharp/releases) — versions are derived from git tags, so there is no fixed number to copy from the docs:
 
 ```xml
 <ItemGroup>
   <!-- Replace with the version shown on NuGet or the releases page. -->
-  <PackageReference Include="MarketDataApp" Version="X.Y.Z-alpha.N" />
+  <PackageReference Include="marketdata.sdk" Version="1.0.0-rc.N" />
 </ItemGroup>
 ```
 
 :::note
-The NuGet **package id** is `MarketDataApp` and the root **namespace** you import is also `MarketDataApp` — for example `using MarketDataApp;`. Endpoint-specific types live under `MarketDataApp.Stocks`, `MarketDataApp.Options`, `MarketDataApp.Funds`, `MarketDataApp.Markets`, and `MarketDataApp.Utilities`.
+The NuGet **package id** is `marketdata.sdk`, but the root **namespace** you import is `MarketDataApp` — for example `using MarketDataApp;`. These differ on purpose: you install `marketdata.sdk` and then write `using MarketDataApp;`. Endpoint-specific types live under `MarketDataApp.Stocks`, `MarketDataApp.Options`, `MarketDataApp.Funds`, `MarketDataApp.Markets`, and `MarketDataApp.Utilities`.
 :::
 
 ## Requirements & Dependencies


### PR DESCRIPTION
Companion to [MarketDataApp/sdk-csharp#71](https://github.com/MarketDataApp/sdk-csharp/pull/71).

The C# SDK now sets an explicit `<PackageId>marketdata.sdk</PackageId>`. Without it the package takes the assembly name and would publish as `MarketDataApp`, which collides with the NuGet organization name and diverges from the sibling SDKs (`marketdata-sdk-java`, `marketdata-sdk-py`).

## Changes

`sdk/csharp/installation.mdx`
- `dotnet add package marketdata.sdk --prerelease`
- NuGet page link → `nuget.org/packages/marketdata.sdk`
- `<PackageReference Include="marketdata.sdk" Version="1.0.0-rc.N" />`
- The package-id note said the id and the namespace were both `MarketDataApp`. They are deliberately different now, so it says so plainly: install `marketdata.sdk`, then write `using MarketDataApp;`.
- Install prose no longer says "while the SDK is in alpha"

`sdk/csharp/index.mdx`
- `:::warning Alpha` → `:::info Release candidate`, ahead of the `1.0.0-rc.1` publish

## Why this repo

`sdk-csharp/docs/` is generated — every path in its `.sync-manifest.txt` is overwritten by the `SDK Docs: Sync to SDK Repos` workflow. These `.mdx` files are the source, so the change belongs here. The sync will carry it downstream on merge to `staging`.