### PR TITLE
docs(sdk): use the C# record ToString() where it matches the hand-rolled string

### DIFF
--- a/sdk/csharp/authentication.mdx
+++ b/sdk/csharp/authentication.mdx
@@ -87,7 +87,7 @@ try
     // and CreateAsync validates it against the API before returning the client.
     using var client = await MarketDataClient.CreateAsync();
     var quote = (await client.Stocks.GetQuoteAsync("SPY")).Values[0];
-    Console.WriteLine($"{quote.Symbol} last={quote.Last}");
+    Console.WriteLine(quote);   // SPY mid=642.18 last=642.05
 }
 catch (AuthenticationException e)
 {

--- a/sdk/csharp/client.mdx
+++ b/sdk/csharp/client.mdx
@@ -14,7 +14,7 @@ using MarketDataApp;
 using var client = await MarketDataClient.CreateAsync();
 
 var quote = (await client.Stocks.GetQuoteAsync("AAPL")).Values[0];
-Console.WriteLine($"{quote.Symbol} last={quote.Last}");
+Console.WriteLine(quote);   // AAPL mid=311.94 last=311.92
 ```
 
 ## MarketDataClient

--- a/sdk/csharp/index.mdx
+++ b/sdk/csharp/index.mdx
@@ -26,7 +26,7 @@ using var client = await MarketDataClient.CreateAsync();
 
 // A single quote — GetQuoteAsync returns a list; a single symbol is row 0.
 var quote = (await client.Stocks.GetQuoteAsync("AAPL")).Values[0];
-Console.WriteLine($"{quote.Symbol} last={quote.Last}");
+Console.WriteLine(quote);   // AAPL mid=311.94 last=311.92
 ```
 
 ## Open Source

--- a/sdk/csharp/markets/status.mdx
+++ b/sdk/csharp/markets/status.mdx
@@ -55,7 +55,7 @@ Console.WriteLine($"US market is {today.Status} on {today.Date:yyyy-MM-dd}");
 var recent = await client.Markets.GetStatusAsync("US", countback: 5);
 foreach (var day in recent.Values)
 {
-    Console.WriteLine($"{day.Date:yyyy-MM-dd}: {day.Status}");
+    Console.WriteLine(day);   // 2026-08-14 open
 }
 ```
 

--- a/sdk/csharp/stocks/candles.mdx
+++ b/sdk/csharp/stocks/candles.mdx
@@ -86,7 +86,7 @@ var candles = await client.Stocks.GetCandlesAsync(
 
 foreach (var bar in candles.Values)
 {
-    Console.WriteLine($"{bar.Time:yyyy-MM-dd}  O={bar.Open} H={bar.High} L={bar.Low} C={bar.Close} V={bar.Volume}");
+    Console.WriteLine(bar);   // 2026-08-14 O=228.10 H=230.44 L=227.55 C=229.88 V=41203118
 }
 
 // The last 10 sessions, using countback instead of a left edge.


### PR DESCRIPTION
Follow-up to [sdk-csharp#76](https://github.com/MarketDataApp/sdk-csharp/pull/76), which simplified the README quick start to use `StockQuote.ToString()`.

Audited **all 29** `Console.WriteLine` sites across the C# docs. Changed **5**. Left **24**.

## Changed

| File | Why |
|---|---|
| `index.mdx`, `client.mdx`, `authentication.mdx` | `StockQuote.ToString()` renders `AAPL mid=311.94 last=311.92` — same data plus mid, and now matches the README quick start |
| `stocks/candles.mdx` | The format string was a **field-for-field reimplementation** of `StockCandle.ToString()` — same fields, same order |
| `markets/status.mdx` (loop) | `MarketStatus.ToString()` renders the same date and status |

```diff
-    Console.WriteLine($"{bar.Time:yyyy-MM-dd}  O={bar.Open} H={bar.High} L={bar.Low} C={bar.Close} V={bar.Volume}");
+    Console.WriteLine(bar);   // 2026-08-14 O=228.10 H=230.44 L=227.55 C=229.88 V=41203118
```

## Deliberately left alone

This is not a blanket sweep. Most remaining sites print fields their page exists to teach, which `ToString()` does not carry — replacing them would make the examples shorter *and worse*:

| Site | Field `ToString()` lacks |
|---|---|
| `stocks/quotes.mdx` | bid/ask; and the 52-week opt-in demo |
| `options/quotes.mdx`, `options/chain.mdx` | IV, delta, open interest, strike, ITM |
| `stocks/earnings.mdx` | estimated EPS, surprise % |
| `utilities/status.mdx` | 30-day uptime |
| `stocks/news.mdx` | source (`ToString()` shows symbol and truncates the headline) |
| `stocks/prices.mdx` | `ChangePct` — `ToString()` carries absolute `Change`, not the percentage |
| `funds/candles.mdx` | deliberately narrowed to NAV close |
| `markets/status.mdx:52` | reads as a prose sentence |
| `options/quotes.mdx:61` | `RequestId`, for the per-symbol fan-out |

The rest aren't record printing at all: error handling and rate limits in `client.mdx`, the header loop in `utilities/headers.mdx`, `settings.mdx` CSV, `options/lookup.mdx` and `options/expirations.mdx`.

## Verification

Output comments were produced by **running** against the published `marketdata.sdk` 1.0.0-rc.1 package, not inferred:

```
StockCandle  -> 2026-08-14 O=228.10 H=230.44 L=227.55 C=229.88 V=41203118
MarketStatus -> 2026-08-14 open
StockQuote   -> AAPL mid=311.94 last=311.92
```

Note `V=41203118` has no thousands separators — `ResponseText.F` is culture-invariant — so the comment reflects real output rather than a prettified guess.