### PR TITLE
docs(sdk): the C# package id is MarketDataApp

### DIFF
--- a/sdk/csharp/installation.mdx
+++ b/sdk/csharp/installation.mdx
@@ -15,22 +15,22 @@ This guide will help you install the Market Data C#/.NET SDK and configure it fo
 Add the SDK as a NuGet package reference. From your project directory:
 
 ```bash
-dotnet add package marketdata.sdk --prerelease
+dotnet add package MarketDataApp --prerelease
 ```
 
 `dotnet add package` resolves the newest version for you and writes it into your project file. While the SDK is a release candidate every published version is a pre-release, so the `--prerelease` flag is required (in an IDE, tick "Include prerelease" in the package manager).
 
-If you maintain the reference by hand, take the version number from the package's [NuGet page](https://www.nuget.org/packages/marketdata.sdk) or the [releases list](https://github.com/MarketDataApp/sdk-csharp/releases) — versions are derived from git tags, so there is no fixed number to copy from the docs:
+If you maintain the reference by hand, take the version number from the package's [NuGet page](https://www.nuget.org/packages/MarketDataApp) or the [releases list](https://github.com/MarketDataApp/sdk-csharp/releases) — versions are derived from git tags, so there is no fixed number to copy from the docs:
 
 ```xml
 <ItemGroup>
   <!-- Replace with the version shown on NuGet or the releases page. -->
-  <PackageReference Include="marketdata.sdk" Version="1.0.0-rc.N" />
+  <PackageReference Include="MarketDataApp" Version="1.0.0-rc.N" />
 </ItemGroup>
 ```
 
 :::note
-The NuGet **package id** is `marketdata.sdk`, but the root **namespace** you import is `MarketDataApp` — for example `using MarketDataApp;`. These differ on purpose: you install `marketdata.sdk` and then write `using MarketDataApp;`. Endpoint-specific types live under `MarketDataApp.Stocks`, `MarketDataApp.Options`, `MarketDataApp.Funds`, `MarketDataApp.Markets`, and `MarketDataApp.Utilities`.
+The NuGet **package id**, the assembly, and the root **namespace** are all `MarketDataApp` — you install `MarketDataApp` and then write `using MarketDataApp;`. Endpoint-specific types live under `MarketDataApp.Stocks`, `MarketDataApp.Options`, `MarketDataApp.Funds`, `MarketDataApp.Markets`, and `MarketDataApp.Utilities`.
 :::
 
 ## Requirements & Dependencies


### PR DESCRIPTION
Companion to [sdk-csharp#79](https://github.com/MarketDataApp/sdk-csharp/pull/79).

The C# SDK no longer overrides `PackageId`, so it defaults to `AssemblyName` — the package id, the assembly and the root namespace are all `MarketDataApp`. That is the .NET convention (Serilog, Dapper, Polly, Newtonsoft.Json, `Microsoft.Extensions.*`), and it means readers only have one name to remember.

## Changes to `sdk/csharp/installation.mdx`

- `dotnet add package MarketDataApp --prerelease`
- NuGet page link → `nuget.org/packages/MarketDataApp`
- `<PackageReference Include="MarketDataApp" Version="1.0.0-rc.N" />`
- The note previously explained the package id and the namespace as two different names. It now states the simpler truth: install `MarketDataApp`, then `using MarketDataApp;`.

## Why this repo

`sdk-csharp/docs/` is generated — every path in its `.sync-manifest.txt` is overwritten by the docs-sync workflow. These `.mdx` files are the source, so the change belongs here and syncs downstream on merge to `staging`.