### PR TITLE
docs(sdk): C#/.NET SDK is stable at 1.0.0

### DIFF
--- a/sdk/csharp/index.mdx
+++ b/sdk/csharp/index.mdx
@@ -10,10 +10,6 @@ Welcome to the Market Data C#/.NET SDK documentation. This SDK lets you integrat
 
 The SDK multi-targets **.NET 8 and .NET 10** (both LTS), integrates with `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.Logging`, and dependency injection out of the box, and works equally well from a console app, a background service, or ASP.NET Core.
 
-:::info Release candidate
-The C#/.NET SDK is a **release candidate**: the public API is feature-complete and no breaking changes are planned before `v1.0.0`. NuGet packages stay pre-release (`1.0.0-rc.N`) until `v1.0.0` is tagged, so installing needs the `--prerelease` flag.
-:::
-
 ## Quick Start
 
 ```csharp

--- a/sdk/csharp/installation.mdx
+++ b/sdk/csharp/installation.mdx
@@ -5,6 +5,13 @@ sidebar_position: 1
 
 This guide will help you install the Market Data C#/.NET SDK and configure it for your project.
 
+|                       |                                                                              |
+|-----------------------|------------------------------------------------------------------------------|
+| **Package**           | [`MarketDataApp`](https://www.nuget.org/packages/MarketDataApp) on NuGet.org |
+| **Target frameworks** | `net8.0`, `net10.0`                                                          |
+| **License**           | MIT                                                                          |
+| **Source**            | [MarketDataApp/sdk-csharp](https://github.com/MarketDataApp/sdk-csharp)      |
+
 ## Prerequisites
 
 - **.NET 8.0 or newer.** The package multi-targets `net8.0` and `net10.0` (both LTS releases), so projects on either runtime get a native build.
@@ -15,17 +22,17 @@ This guide will help you install the Market Data C#/.NET SDK and configure it fo
 Add the SDK as a NuGet package reference. From your project directory:
 
 ```bash
-dotnet add package MarketDataApp --prerelease
+dotnet add package MarketDataApp
 ```
 
-`dotnet add package` resolves the newest version for you and writes it into your project file. While the SDK is a release candidate every published version is a pre-release, so the `--prerelease` flag is required (in an IDE, tick "Include prerelease" in the package manager).
+`dotnet add package` resolves the newest stable version for you and writes it into your project file.
 
 If you maintain the reference by hand, take the version number from the package's [NuGet page](https://www.nuget.org/packages/MarketDataApp) or the [releases list](https://github.com/MarketDataApp/sdk-csharp/releases) — versions are derived from git tags, so there is no fixed number to copy from the docs:
 
 ```xml
 <ItemGroup>
   <!-- Replace with the version shown on NuGet or the releases page. -->
-  <PackageReference Include="MarketDataApp" Version="1.0.0-rc.N" />
+  <PackageReference Include="MarketDataApp" Version="1.0.0" />
 </ItemGroup>
 ```
 
@@ -41,6 +48,16 @@ The SDK stays on the standard Microsoft stack, with one small helper:
 - **`System.Text.Json`** for JSON decoding — no Newtonsoft dependency.
 - **`Microsoft.Extensions.Configuration`** (with the environment-variables and user-secrets providers), **`Microsoft.Extensions.Logging`**, and **`Microsoft.Extensions.DependencyInjection`** for configuration binding, structured logging, and the `AddMarketDataClient` service-collection extension.
 - **`DotNetEnv`** to load an optional `.env` file from the working directory.
+
+## Updating the SDK
+
+To move to the latest stable version:
+
+```bash
+dotnet add package MarketDataApp
+```
+
+The SDK follows [semantic versioning](https://semver.org/) from `1.0.0`, so a `1.x` update never contains a breaking change. Review the [release notes](https://github.com/MarketDataApp/sdk-csharp/releases) before moving to a new major version.
 
 ## Next Steps
 


### PR DESCRIPTION
Companion to [sdk-csharp#88](https://github.com/MarketDataApp/sdk-csharp/pull/88), which promotes the SDK to a stable `1.0.0`.

## Changes

**`index.mdx`** — the `:::info Release candidate` admonition is removed. The API is stable and covered by semantic versioning.

**`installation.mdx`**
- `dotnet add package MarketDataApp` — the `--prerelease` flag is gone, since the package now resolves as stable
- `<PackageReference ... Version="1.0.0" />` in the manual-reference example
- The prose no longer explains that every published version is a pre-release
- New **package facts table**: package + NuGet link, target frameworks, license, source
- New **Updating the SDK** section, mirroring the shape the PHP installation page already uses

## Two deliberate choices

**No shields badges.** I was going to add NuGet version and download badges, then checked — nothing on the docs site uses `img.shields.io`, and none of the sibling SDK installation pages do either. Plain prose and tables is the house style.

**No version number in the table.** The page already tells readers to take the version from the NuGet page or the releases list, so a number written here would contradict that and go stale the moment a release lands. The NuGet link is the single source of truth.

## Note

Once this reaches production, `https://www.marketdata.app/docs/sdk/csharp/` stops returning 404. That unblocks the items tracked in [sdk-csharp#70](https://github.com/MarketDataApp/sdk-csharp/issues/70) — pointing `MARKETDATA_DOCS_HOST` at production, and switching the repository's About-box homepage from the SDK index to the C#-specific page.