### PR TITLE
chore(redirects): drop @docusaurus/plugin-client-redirects

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -88,12 +88,6 @@ const config = {
     './plugins/markdown-twins',
     './plugins/redirects-file',
     [
-      "@docusaurus/plugin-client-redirects",
-      {
-        redirects: REDIRECTS,
-      },
-    ],
-    [
       "@docusaurus/plugin-content-docs",
       /** @type {import('@docusaurus/plugin-content-docs').Options} */
       {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.0.1",
-    "@docusaurus/plugin-client-redirects": "3.0.1",
     "@docusaurus/plugin-content-docs": "3.0.1",
     "@docusaurus/preset-classic": "3.0.1",
     "@marketdataapp/ui": "github:MarketDataApp/ui#v4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1346,21 +1346,6 @@
     react-helmet-async "*"
     react-loadable "npm:@docusaurus/react-loadable@5.5.2"
 
-"@docusaurus/plugin-client-redirects@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.0.1.tgz#9a54479e1276c49903bf6c765c801fa810f4bd18"
-  integrity sha512-CoZapnHbV3j5jsHCa/zmKaa8+H+oagHBgg91dN5I8/3kFit/xtZPfRaznvDX49cHg2nSoV74B3VMAT+bvCmzFQ==
-  dependencies:
-    "@docusaurus/core" "3.0.1"
-    "@docusaurus/logger" "3.0.1"
-    "@docusaurus/utils" "3.0.1"
-    "@docusaurus/utils-common" "3.0.1"
-    "@docusaurus/utils-validation" "3.0.1"
-    eta "^2.2.0"
-    fs-extra "^11.1.1"
-    lodash "^4.17.21"
-    tslib "^2.6.0"
-
 "@docusaurus/plugin-content-blog@3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.0.1.tgz#dee6147187c2d8b634252444d60312d12c9571a6"


### PR DESCRIPTION
**Step 2 of 3.** Cloudflare now serves the redirects natively, so the plugin's only output — a stub page per redirect — is unreachable.

## Proved on staging before this PR, not assumed

| | GET | HEAD |
|---|---|---|
| origin `pages.dev` (no worker) | **301** | **301** |
| through the worker route | **301** | **301** |

Full suite against staging: **58/58** (19 × GET, HEAD, destination).

And it is provably Cloudflare's redirect, not the worker's conversion:

| | worker's version | what staging returns now |
|---|---|---|
| Location | absolute, rebuilt from the request host | **relative** `/docs/api/troubleshooting/` |
| Content-Type | `text/html` | **`text/plain;charset=UTF-8`** |

The relative Location is also why one rule serves both hosts — the worker had to reconstruct an absolute URL to do the same job.

## What this removes

- 19 dead stub pages from every build (redirects take precedence over assets, so they were already unreachable)
- one dependency from the tree

Verified after removal: **0** of the 19 stub pages remain in `build/`, and all **19** rules are still written to `_redirects`.

## Next

Step 3 deletes the stub-conversion block from the worker — the code that read every `/docs/` HTML body under 4 KB to fake these 301s.