### PR TITLE
fix(sheets): link STOCKDATA directly instead of through a redirect

### DIFF
--- a/sheets/troubleshooting/urlfetch.md
+++ b/sheets/troubleshooting/urlfetch.md
@@ -51,7 +51,7 @@ If you make a habit of using Copy & Paste Values for your historical outputs, yo
 
 ### Use A Single Formula For All Your Real-Time Quotes
 
-Instead of using multiple [`STOCKDATA`](/sheets/stockdata) formulas in your spreadsheet, use a single formula and send all the tickers you need at once. Not only will this use just one urlfetch call, but it will also speed up the loading process of your spreadsheet.
+Instead of using multiple [`STOCKDATA`](/sheets/stocks/stockdata) formulas in your spreadsheet, use a single formula and send all the tickers you need at once. Not only will this use just one urlfetch call, but it will also speed up the loading process of your spreadsheet.
 
 ### Refresh Prices Less Often
 


### PR DESCRIPTION
Fixes the `broken-links` failure introduced by dropping `@docusaurus/plugin-client-redirects` (#180).

## What happened

`sheets/troubleshooting/urlfetch.md` linked `/sheets/stockdata` — a redirect **source**, not a page. While the plugin was installed it emitted a stub page there, so Docusaurus counted the path as a real route and the link check passed. Removing the plugin removed the stub:

```
On source page path = /docs/sheets/troubleshooting/urlfetch/:
   -> linking to /docs/sheets/stockdata/
```

**The link never stopped working** — Cloudflare's `_redirects` rule 301s it, and production serves it correctly. Docusaurus's build-time check simply has no knowledge of `_redirects`. Pointing a link at a redirect when you know the destination is a hop nobody needs, so the fix is to name it: `/sheets/stocks/stockdata`.

## Why it wasn't caught earlier

`pr-checks.yml` owns the broken-links gate and runs **only on PRs to `main`**. #178 and #179 targeted `staging`, so it never ran on them. It fired on the first PR to `main` afterwards — the hotfix — and I merged that before reading it. My mistake.

## Scope

This is the **only** occurrence. Every redirect source in `redirects.js` was searched for both the `/docs`-prefixed and bare link forms; one hit.

Verified locally: `STRICT_LINKS=true yarn build` now succeeds, 18 rules still written.