### PR TITLE
fix(sheets): link STOCKDATA directly instead of through a redirect (staging)

### DIFF
--- a/sheets/troubleshooting/urlfetch.md
+++ b/sheets/troubleshooting/urlfetch.md
@@ -51,7 +51,7 @@ If you make a habit of using Copy & Paste Values for your historical outputs, yo
 
 ### Use A Single Formula For All Your Real-Time Quotes
 
-Instead of using multiple [`STOCKDATA`](/sheets/stockdata) formulas in your spreadsheet, use a single formula and send all the tickers you need at once. Not only will this use just one urlfetch call, but it will also speed up the loading process of your spreadsheet.
+Instead of using multiple [`STOCKDATA`](/sheets/stocks/stockdata) formulas in your spreadsheet, use a single formula and send all the tickers you need at once. Not only will this use just one urlfetch call, but it will also speed up the loading process of your spreadsheet.
 
 ### Refresh Prices Less Often
 


### PR DESCRIPTION
The `staging` half of #181. Same one-line change, cherry-picked.

`sheets/troubleshooting/urlfetch.md` linked `/sheets/stockdata`, a redirect **source**. The client-redirects plugin used to emit a stub page there so Docusaurus counted it as a route; with the plugin gone, the strict build fails on it.

It surfaced on `main` first only because `pr-checks.yml` runs the broken-links gate exclusively on PRs to `main` — `staging` has the same content and the same latent failure.

The link never stopped working: Cloudflare's `_redirects` rule 301s it. This just names the destination directly, saving a hop.