### PR TITLE
fix(redirects): emit both slash forms — all 18 bare sources are 404ing

### DIFF
--- a/plugins/redirects-file.js
+++ b/plugins/redirects-file.js
@@ -4,6 +4,10 @@
  * Writes the documentation redirects into the build as Cloudflare `_redirects`
  * rules, so Pages serves a real 301 instead of a page that fakes one.
  *
+ * TWO RULES PER REDIRECT, bare and slashed. This is the correction to a
+ * regression, and the reasoning is not obvious, so it is written out below
+ * under "Why both slash forms".
+ *
  * ---------------------------------------------------------------------------
  * What this replaces
  * ---------------------------------------------------------------------------
@@ -31,15 +35,31 @@
  * identically, and needs no code at the edge at all.
  *
  * ---------------------------------------------------------------------------
- * Why the trailing slash, and why only one rule per redirect
+ * Why both slash forms
  * ---------------------------------------------------------------------------
  *
- * `trailingSlash: true`, so `/docs/x` is not a real URL here -- Pages
- * normalises it with a 308 to `/docs/x/` and the rule matches on the second
- * hop. That is already the observed behaviour: before this plugin existed,
- * `/docs/api/troubleshooting/http-status-codes` answered 308 and then the
- * worker's 301. One rule in the slashed form therefore covers both spellings,
- * and a second rule for the bare form would be dead weight.
+ * This plugin originally emitted only the slashed form, reasoning that
+ * `trailingSlash: true` means Pages normalises `/docs/x` to `/docs/x/` with a
+ * 308 and the rule matches on the second hop. That was observed behaviour at
+ * the time, and it was true for the wrong reason.
+ *
+ * Cloudflare only normalises a trailing slash when a DIRECTORY exists at that
+ * path. Measured 2026-08-25:
+ *
+ *   /definitely-not-a-page   404              no directory -> no normalisation
+ *   /pricing                 308 -> /pricing/ directory exists -> normalised
+ *
+ * While @docusaurus/plugin-client-redirects was installed, every redirect
+ * source had a stub page and therefore a directory, so the bare form
+ * normalised. Removing the plugin removed the directories -- and a redirect
+ * source has no directory by definition, since the point of it is that the page
+ * is gone. All 18 bare forms went from 308-then-301 to a flat 404 on both
+ * hosts, silently, because the slashed form kept working and that is what
+ * everything tested.
+ *
+ * So both spellings need their own rule. MarketDataApp/website's hand-written
+ * _redirects has paired them all along for exactly this reason; the pairing
+ * looked redundant until it was measured.
  *
  * ---------------------------------------------------------------------------
  * Where the file lands
@@ -118,15 +138,22 @@ module.exports = function redirectsFilePlugin() {
         '# stub pages Docusaurus emits for the same paths and answer every',
         '# method the same way. Nothing at the edge is involved.',
         '',
-        ...REDIRECTS.map(({ from, to }) => `${PREFIX}${from}/  ${PREFIX}${to}/  301`),
+        // Bare first, then slashed. Order is irrelevant to Cloudflare here --
+        // the two sources are distinct literals and cannot both match one
+        // request -- but keeping the pair adjacent makes a missing half
+        // visible when reading the generated file.
+        ...REDIRECTS.flatMap(({ from, to }) => [
+          `${PREFIX}${from}   ${PREFIX}${to}/  301`,
+          `${PREFIX}${from}/  ${PREFIX}${to}/  301`,
+        ]),
         '',
       ];
 
       await fs.writeFile(path.join(outDir, '_redirects'), lines.join('\n'), 'utf8');
 
       console.log(
-        `[redirects-file] ${REDIRECTS.length} redirect(s) written to _redirects; ` +
-          'none shadow a built page'
+        `[redirects-file] ${REDIRECTS.length} redirect(s) written to _redirects ` +
+          `as ${REDIRECTS.length * 2} rules (bare and slashed); none shadow a built page`
       );
 
       if (REDIRECTS.length === 0) {

--- a/tests/redirects.integration.test.js
+++ b/tests/redirects.integration.test.js
@@ -15,6 +15,13 @@
  * `_redirects` rules served by Cloudflare Pages, so this asserts what actually
  * matters: the status is 301 and Location names the destination.
  *
+ * BOTH SLASH FORMS ARE TESTED, and that gap is why a regression shipped. The
+ * suite originally probed only `<from>/`. Cloudflare normalises a bare path to
+ * its slashed form only when a DIRECTORY exists there, and dropping
+ * @docusaurus/plugin-client-redirects removed the stub pages that were
+ * providing those directories -- so all 18 bare forms went from working to a
+ * flat 404 on both hosts while every test stayed green.
+ *
  * HEAD IS TESTED, and that is the point of the exercise. The old arrangement
  * could not work for HEAD -- a HEAD response has no body, so the worker's
  * match never fired and every one of these answered 301 to GET and 200 to
@@ -64,22 +71,29 @@ for (const [env, host] of Object.entries(envs)) {
     });
 
     for (const { from, to } of REDIRECTS) {
-      const fromUrl = `${host}${PREFIX}${from}/`;
       const toUrl = `${host}${PREFIX}${to}/`;
 
-      test(`GET ${from} -> ${to}`, async () => {
-        const res = await fetch(fromUrl, { redirect: 'manual' });
-        assert.equal(res.status, 301, `${from} returned ${res.status}`);
-        assert.equal(resolve(res.headers.get('location'), fromUrl), toUrl);
-      });
+      // Both spellings, because they are separate rules in _redirects and a
+      // missing one fails silently -- the other keeps working, so nothing
+      // reports it. `slashed` is the canonical form; `bare` is what somebody
+      // typed or an old link carries.
+      for (const [label, fromUrl] of [
+        ['bare', `${host}${PREFIX}${from}`],
+        ['slashed', `${host}${PREFIX}${from}/`],
+      ]) {
+        test(`GET ${from} (${label}) -> ${to}`, async () => {
+          const res = await fetch(fromUrl, { redirect: 'manual' });
+          assert.equal(res.status, 301, `${label} ${from} returned ${res.status}`);
+          assert.equal(resolve(res.headers.get('location'), fromUrl), toUrl);
+        });
 
-      // The case the old suite could not express. Identical expectations to
-      // GET -- that is the whole claim.
-      test(`HEAD ${from} -> ${to}`, async () => {
-        const res = await fetch(fromUrl, { method: 'HEAD', redirect: 'manual' });
-        assert.equal(res.status, 301, `HEAD ${from} returned ${res.status}`);
-        assert.equal(resolve(res.headers.get('location'), fromUrl), toUrl);
-      });
+        // Identical expectations to GET -- that is the whole claim.
+        test(`HEAD ${from} (${label}) -> ${to}`, async () => {
+          const res = await fetch(fromUrl, { method: 'HEAD', redirect: 'manual' });
+          assert.equal(res.status, 301, `HEAD ${label} ${from} returned ${res.status}`);
+          assert.equal(resolve(res.headers.get('location'), fromUrl), toUrl);
+        });
+      }
 
       test(`destination ${to} exists`, async () => {
         const res = await fetch(toUrl, { redirect: 'manual' });


### PR DESCRIPTION
**Live regression on both hosts.** Every redirect source without a trailing slash returns 404.

```
/docs/api/troubleshooting/http-status-codes    404   (was 308 -> 301)
/docs/api/troubleshooting/http-status-codes/   301   (fine throughout)
```

18 of 18 bare forms on production, 18 of 18 on staging. The slashed form kept working, which is why nothing reported it.

## Cause — true for the wrong reason

This plugin emitted only the slashed form, reasoning that `trailingSlash: true` means Pages normalises `/docs/x` → `/docs/x/` with a 308, so one rule covers both. That **was** the observed behaviour when I wrote it.

Cloudflare only normalises a trailing slash when a **directory** exists at that path:

```
/definitely-not-a-page   404               no directory -> no normalisation
/pricing                 308 -> /pricing/  directory exists -> normalised
```

While `@docusaurus/plugin-client-redirects` was installed, every redirect source had a stub page and therefore a directory, so the bare form normalised. Removing the plugin removed the directories — and a redirect source has no directory *by definition*, since the whole point is that the page is gone.

`MarketDataApp/website`'s hand-written `_redirects` has paired both forms all along. That pairing looked redundant until I measured it; the same measurement found this.

## Fix

36 rules from 18 redirects — bare and slashed, kept adjacent so a missing half is visible when reading the generated file.

## The test gap that let it ship

The suite probed only `<from>/`. It now probes **both spellings, for GET and HEAD**.

Verified the updated suite fails against production as it stands — **91 tests, 55 pass, 36 fail**, one per bare form per method — so it demonstrably catches what it was blind to.