### PR TITLE
docs(sitemap): record why a cache-warm probe undercounts dead pages (#188)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,40 @@ deleted from R2 after the build by `aws s3 sync --delete`.
 delete and an upload for the same key and races them; see the comment above the
 "Upload to R2" step for the measurements.
 
+### Cache-warm vs cache-busted probes
+
+**When a page count matters, cache-bust.** A plain request is served from the
+Cloudflare edge, so it can return 200 for a page that is no longer in the
+deployment — for as long as the cache entry lives, which was over two days
+during #188.
+
+| Probe        | Request                          | Answers                                |
+|--------------|----------------------------------|----------------------------------------|
+| Cache-warm   | `curl <url>`                     | what a visitor is served **right now** |
+| Cache-busted | `curl "<url>?cb=$RANDOM$RANDOM"` | what the **deployment** contains       |
+
+Cloudflare puts the query string in the cache key, so a unique value forces a
+miss and a fetch from the origin.
+
+> A cache-warm probe measures delivery, a cache-busted probe measures the
+> deployment, and only the second one can tell you what a fresh visitor will get
+> tomorrow.
+
+Run both and compare. **A disagreement is a delayed failure, already queued** —
+the page looks correct today and starts 404ing when the cache expires, with no
+new deploy and no new cause.
+
+Three numbers in #188 were wrong for want of this: the original count of 15, a
+later count of 16, and the production 404 traffic figure. That last one is
+edge-side, so a dead URL served 200 from a warm cache never enters the 404
+report at all — those counts are a floor, not a total, and the flaw is
+self-concealing, because anyone testing the tooling against a known-dead URL
+sees 200s and concludes it works.
+
+`tests/sitemap.integration.test.js` is deliberately cache-warm: it is the only
+check that reads what the public reads. A green run there proves delivery, not
+completeness.
+
 ## Testing
 
 - **Unit tests**: `cd worker && yarn test` — tests worker routing, markdown serving, robots.txt, 404 logging

--- a/tests/sitemap.integration.test.js
+++ b/tests/sitemap.integration.test.js
@@ -26,6 +26,47 @@
  * reads what the public reads.
  *
  * ---------------------------------------------------------------------------
+ * What this measures, and what it CANNOT measure
+ * ---------------------------------------------------------------------------
+ *
+ * This probe is cache-warm: a plain GET, served by whatever Cloudflare has at
+ * the edge. That is deliberate -- it is the only check here that sees what a
+ * visitor sees. But it means a green run proves DELIVERY, not that the
+ * deployment contains the page.
+ *
+ * Those two diverge whenever a file leaves the origin while an edge copy
+ * survives, and they stay diverged for the life of the cache entry. Measured
+ * on 2026-08-27, mid-#188:
+ *
+ *     plain    ?cb=<random>
+ *      200         404      /docs/sdk/csharp/                 HIT, age 179581
+ *      200         404      /docs/sdk/go/stocks/bulkquotes/   HIT, age 171723
+ *      200         200      /docs/api/stocks/    (control, genuinely present)
+ *
+ * `age: 179581` is 2.08 days -- exactly the deploy that deleted them. Both
+ * pages were absent from production and being served from a stale edge copy,
+ * and both would have passed this suite.
+ *
+ * Cloudflare puts the query string in the cache key, so a unique value per
+ * request forces a miss and the edge must fetch from the origin. That is the
+ * whole trick:
+ *
+ *     a cache-warm probe measures delivery, a cache-busted probe measures the
+ *     deployment, and only the second can tell you what a fresh visitor will
+ *     get tomorrow.
+ *
+ * Three numbers in #188 were wrong for want of that distinction: the issue's
+ * original count of 15, a later count of 16, and the traffic figure -- which
+ * is edge-side, so a dead URL served 200 from cache never enters the 404
+ * report and the total is a floor rather than a count.
+ *
+ * WHEN A NUMBER FROM THIS SUITE MATTERS, cache-bust as well and compare. A
+ * disagreement is not noise; it is a delayed failure, already queued, that
+ * will surface when the cache expires with no new deploy and no new cause.
+ *
+ *     curl -s -o /dev/null -w '%{http_code}' "<url>?cb=$RANDOM$RANDOM"
+ *
+ * ---------------------------------------------------------------------------
  * Why staging asserts the OPPOSITE
  * ---------------------------------------------------------------------------
  *


### PR DESCRIPTION
Follow-up to #190 / #191, closing the last gap from #188.

Three numbers in that issue were wrong for one reason — they were measured through a warm Cloudflare edge cache — and the reason lived only in an issue thread.

```
     plain    ?cb=<random>
      200         404      /docs/sdk/csharp/                 HIT, age 179581
      200         404      /docs/sdk/go/stocks/bulkquotes/   HIT, age 171723
      200         200      /docs/api/stocks/    (control, genuinely present)
```

`age 179581` is 2.08 days — exactly the deploy that deleted them. It cost the original count of 15, a later count of 16 (the truth was 18), and the traffic figure, which is edge-side and therefore a floor rather than a total.

Recorded where a reader meets it: the CLAUDE.md sitemap section, and the header of `tests/sitemap.integration.test.js` — which is deliberately cache-warm, and documented what it asserts without naming what it cannot see.

**Comments and documentation only.** No test, script or workflow behaviour changes.