### PR TITLE
fix(ci): wait for the deploy to land before probing the live site (#185)

### DIFF
--- a/.github/workflows/post-deploy-tests.yml
+++ b/.github/workflows/post-deploy-tests.yml
@@ -28,6 +28,21 @@ jobs:
       #
       # No install step -- `node --test` against the standard library and
       # global fetch. The root `yarn install` above stays for the e2e run.
+      # #185. This job fires on `deploy-complete`, but the orchestrator reports
+      # success before Cloudflare has finished propagating -- measured at ~47s
+      # once, upper bound unknown. Every suite below probes the live site, so
+      # they all sit in that tail; the sitemap one probes 258 URLs and is the
+      # widest surface of the three.
+      #
+      # The wait probes cache-busted on purpose. A warm probe is answered by the
+      # PREVIOUS deployment's edge copy and would report ready before anything
+      # propagated -- during #188 two deleted pages answered 200 that way for
+      # 2.08 days.
+      - name: Wait for the deploy to propagate
+        env:
+          TEST_ENV: ${{ github.event.client_payload.environment }}
+        run: yarn wait:deploy
+
       - name: Run redirect tests
         env:
           TEST_ENV: ${{ github.event.client_payload.environment }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -87,6 +87,22 @@ jobs:
       # library and global fetch, so it needs no dependencies -- it used to
       # borrow worker/'s vitest, and worker/ has gone. Same reason there is no
       # `cache: yarn` here any more: there is no lockfile to key it on.
+      # #185: this job probes the LIVE staging site, which a merge to `staging`
+      # takes through a ~5 minute deploy chain. A run landing inside that window
+      # fails on pages that are mid-deploy, with a message identical to a broken
+      # redirect -- and telling the two apart cost correlating timestamps across
+      # two workflows in two repositories.
+      #
+      # This waits instead of retrying. A retry charges its delay to every
+      # genuine failure forever, and automates the "it passed second time, must
+      # be flake" reflex that #185 is about. The wait costs nothing when the
+      # site is ready, and it never fails the job: on timeout it says what is
+      # still down and lets the suites be the judges.
+      - name: Wait for staging to finish deploying
+        env:
+          TEST_ENV: staging
+        run: yarn wait:deploy
+
       - name: Run redirect tests against staging
         env:
           TEST_ENV: staging
@@ -128,6 +144,14 @@ jobs:
       - run: yarn install --frozen-lockfile
 
       - run: npx playwright install chromium
+
+      # Same deploy race as the integration job above (#185). This suite drives
+      # a real browser against the same host and can fail the same way; that it
+      # has not yet is luck rather than design.
+      - name: Wait for staging to finish deploying
+        env:
+          TEST_ENV: staging
+        run: yarn wait:deploy
 
       - name: Run e2e tests against staging
         env:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:lib": "node --test lib/__tests__/*.test.js",
     "test:redirects": "node --test tests/redirects.integration.test.js",
     "test:sitemap": "node --test tests/sitemap.integration.test.js",
+    "wait:deploy": "node scripts/wait-for-deploy.js",
     "lint:links": "STRICT_LINKS=true yarn build",
     "lint:sitemap": "PROD=true yarn build && node scripts/lint-sitemap.js",
     "lint:tables": "node scripts/fix-table-alignment.js",

--- a/scripts/__tests__/wait-for-deploy.test.js
+++ b/scripts/__tests__/wait-for-deploy.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { hostFor, targetsFor, bust, HOSTS, PREFIX } = require('../wait-for-deploy');
+const { REDIRECTS } = require('../../redirects');
+
+describe('wait-for-deploy', () => {
+  test('resolves both hosts', () => {
+    assert.equal(hostFor('staging'), HOSTS.staging);
+    assert.equal(hostFor('production'), HOSTS.production);
+  });
+
+  test('rejects an unknown environment rather than defaulting to one', () => {
+    // Defaulting would wait on the wrong host and report it ready, which is
+    // worse than not waiting at all.
+    assert.throws(() => hostFor('prod'), /unknown TEST_ENV/);
+    assert.throws(() => hostFor(''), /unknown TEST_ENV/);
+  });
+
+  test('probes redirect destinations, under /docs, slashed', () => {
+    const urls = targetsFor(HOSTS.production);
+    assert.ok(urls.length > 0, 'no probe URLs');
+    for (const u of urls) {
+      assert.ok(u.startsWith(`${HOSTS.production}${PREFIX}/`), `not under ${PREFIX}: ${u}`);
+      assert.ok(u.endsWith('/'), `not slashed: ${u}`);
+    }
+  });
+
+  test('the probe list cannot drift from redirects.js', () => {
+    const expected = new Set(REDIRECTS.map((r) => r.to));
+    const got = new Set(
+      targetsFor(HOSTS.production).map((u) =>
+        u.slice(`${HOSTS.production}${PREFIX}`.length).replace(/\/$/, '')
+      )
+    );
+    assert.deepEqual([...got].sort(), [...expected].sort());
+  });
+
+  test('de-duplicates destinations shared by several redirects', () => {
+    const urls = targetsFor(HOSTS.production);
+    assert.equal(urls.length, new Set(urls).size);
+  });
+
+  test('every attempt gets a distinct cache-buster', () => {
+    // A readiness probe served from a warm edge copy reports the PREVIOUS
+    // deployment as ready. Two deleted pages answered 200 from cache for
+    // 2.08 days during #188, so this is the property that makes the wait mean
+    // anything.
+    const url = 'https://www.marketdata.app/docs/api/stocks/';
+    const a = bust(url, 1, 0);
+    const b = bust(url, 2, 0);
+    const c = bust(url, 2, 1);
+    assert.notEqual(a, b);
+    assert.notEqual(b, c);
+    for (const u of [a, b, c]) {
+      assert.ok(new URL(u).searchParams.get('cb'), `no cb param: ${u}`);
+      assert.equal(new URL(u).pathname, '/docs/api/stocks/');
+    }
+  });
+});

--- a/scripts/wait-for-deploy.js
+++ b/scripts/wait-for-deploy.js
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Waits until the live site has finished deploying, before a suite probes it.
+ *
+ * ---------------------------------------------------------------------------
+ * The problem this removes
+ * ---------------------------------------------------------------------------
+ *
+ * `pr-checks.yml` and `post-deploy-tests.yml` probe the LIVE site. A merge to
+ * `staging` takes that site through a ~5 minute chain -- docs build, R2 sync,
+ * orchestrator merge, Pages deploy -- during which a SUBSET of pages 404. A
+ * check that runs inside that window fails for reasons unrelated to the change
+ * under test, and the failure is indistinguishable from a broken redirect:
+ *
+ *     destination /account/troubleshooting/linkedin-issues returned 404
+ *
+ * That is #185. The cost is not the re-run, it is that the only way to tell a
+ * race from a regression was to correlate timestamps across two workflows in
+ * two repositories -- and nobody does that at 5pm. They hit re-run, it passes,
+ * and they file it under flake.
+ *
+ * WHICH IS EXACTLY HOW A REAL FAILURE HID. On 2026-08-26 this job went red
+ * with that same signature and stayed red, and it was not a race: it was #188,
+ * 57 genuinely deleted pages on staging. It cleared only when the defect was
+ * fixed. A check people have been taught to distrust reports nothing when it
+ * is right.
+ *
+ * ---------------------------------------------------------------------------
+ * Why a wait and not a retry
+ * ---------------------------------------------------------------------------
+ *
+ * #185 proposes retrying the suite once after 90s. That works, but it charges
+ * the 90s to every GENUINE failure, forever, and it automates the very reflex
+ * the issue warns about -- "it passed on the second go, must be flake".
+ *
+ * Waiting first costs nothing when the site is ready, which is almost always,
+ * and costs only as long as the deploy actually takes when it is not.
+ *
+ * ---------------------------------------------------------------------------
+ * Two properties that are easy to get wrong
+ * ---------------------------------------------------------------------------
+ *
+ * IT PROBES CACHE-BUSTED. A readiness probe served from a warm edge copy
+ * reports the PREVIOUS deployment as ready. That is not hypothetical here:
+ * during #188 two deleted pages answered 200 from the edge for 2.08 days.
+ * Cloudflare puts the query string in the cache key, so each attempt carries a
+ * fresh one and the answer comes from the origin.
+ *
+ * IT NEVER FAILS THE BUILD. It is a wait, not an assertion -- the suites are
+ * the judges, and they say which URL is wrong. On timeout it proceeds anyway
+ * and prints what is still down, so the run reads
+ *
+ *     waited 300s, 3 of 19 still 404 -- running anyway
+ *
+ * instead of leaving someone to correlate timestamps by hand. That line is the
+ * whole point: it turns the diagnosis #185 describes as expensive into one a
+ * reader gets for free.
+ *
+ * Run with: TEST_ENV=staging yarn wait:deploy
+ */
+
+const { REDIRECTS } = require('../redirects');
+
+const HOSTS = {
+  staging: 'https://www-staging.marketdata.app',
+  production: 'https://www.marketdata.app',
+};
+
+const PREFIX = '/docs';
+
+/** How long to wait before giving up and running the suite regardless. */
+const TIMEOUT_MS = Number(process.env.WAIT_TIMEOUT_MS || 300_000);
+const INTERVAL_MS = Number(process.env.WAIT_INTERVAL_MS || 10_000);
+const CONCURRENCY = 12;
+
+function hostFor(env) {
+  const host = HOSTS[env];
+  if (!host) {
+    throw new Error(
+      `unknown TEST_ENV "${env}". Expected one of: ${Object.keys(HOSTS).join(', ')}`
+    );
+  }
+  return host;
+}
+
+/**
+ * The URLs whose readiness stands for the site's. The redirect DESTINATIONS,
+ * because they are the pages #185's failures actually named, they are spread
+ * across every docs section, and importing them from redirects.js means this
+ * list cannot drift from what the redirect suite asserts.
+ */
+function targetsFor(host) {
+  return [...new Set(REDIRECTS.map((r) => `${host}${PREFIX}${r.to}/`))];
+}
+
+/** Cloudflare keys its cache on the query string, so this forces a miss. */
+function bust(url, attempt, index) {
+  const u = new URL(url);
+  u.searchParams.set('cb', `${Date.now()}-${attempt}-${index}`);
+  return u.toString();
+}
+
+async function pooled(items, worker) {
+  const out = [];
+  let next = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, items.length) }, async () => {
+      while (next < items.length) {
+        const i = next++;
+        out[i] = await worker(items[i], i);
+      }
+    })
+  );
+  return out;
+}
+
+async function probe(urls, attempt) {
+  return pooled(urls, async (url, i) => {
+    try {
+      const res = await fetch(bust(url, attempt, i), { redirect: 'manual' });
+      await res.body?.cancel();
+      return { url, ok: res.status === 200, status: res.status };
+    } catch (err) {
+      return { url, ok: false, status: `error: ${err.message}` };
+    }
+  });
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function main() {
+  const env = process.env.TEST_ENV;
+  if (!env) {
+    console.log('[wait-for-deploy] TEST_ENV is not set; nothing to wait for');
+    return;
+  }
+
+  const host = hostFor(env);
+  const urls = targetsFor(host);
+
+  // A wait over an empty list would return "ready" instantly and mean nothing.
+  if (urls.length === 0) {
+    console.log('[wait-for-deploy] no target URLs; skipping the wait');
+    return;
+  }
+
+  const started = Date.now();
+  let attempt = 0;
+  let down = [];
+
+  while (Date.now() - started < TIMEOUT_MS) {
+    attempt++;
+    const results = await probe(urls, attempt);
+    down = results.filter((r) => !r.ok);
+
+    if (down.length === 0) {
+      const secs = Math.round((Date.now() - started) / 1000);
+      console.log(
+        `[wait-for-deploy] ${env} ready: ${urls.length} of ${urls.length} ` +
+          `probe URL(s) answered 200 (cache-busted) after ${secs}s`
+      );
+      return;
+    }
+
+    console.log(
+      `[wait-for-deploy] ${env} not ready: ${down.length} of ${urls.length} ` +
+        `not answering 200; waiting ${INTERVAL_MS / 1000}s`
+    );
+    await sleep(INTERVAL_MS);
+  }
+
+  const secs = Math.round((Date.now() - started) / 1000);
+  const detail = down.map((d) => `    ${d.status}  ${d.url.split('?')[0]}`).join('\n');
+  console.log(
+    `::warning::[wait-for-deploy] waited ${secs}s, ${down.length} of ${urls.length} ` +
+      'probe URL(s) still not answering 200 -- running the suite anyway'
+  );
+  console.log(detail);
+  console.log(
+    '[wait-for-deploy] if the suite now fails on these same URLs, it is more\n' +
+      '  likely a real regression than a deploy race: the wait above already\n' +
+      '  outlasted a normal deploy.'
+  );
+}
+
+module.exports = { hostFor, targetsFor, bust, HOSTS, PREFIX };
+
+if (require.main === module) {
+  main().catch((err) => {
+    // Still not a gate. A broken waiter must not fail a run the suites can judge.
+    console.log(`::warning::[wait-for-deploy] ${err.message} -- running the suite anyway`);
+  });
+}


### PR DESCRIPTION
Production branch. Same commit as #194 (which targets `staging`), cherry-picked onto `main` so it ships without the Go v2 SDK work `staging` still carries.

Five files, additions only, no docs content. `main`'s own `npx playwright install chromium` step is left exactly as it is — see the note at the bottom.

Fixes #185.

## The race, and the failure it hid

`pr-checks.yml` and `post-deploy-tests.yml` probe the **live** site. A merge to `staging` takes it through a ~5 minute chain during which a subset of pages 404, and a check landing inside that window fails with a message identical to a broken redirect. Telling the two apart meant correlating timestamps across two workflows in two repositories — so nobody did.

**That is not hypothetical any more.** On 2026-08-26 `staging-integration-tests` went red with #185's exact signature:

```
#185 (the race)                            2026-08-26 (real)
/account/troubleshooting/linkedin-issues   /account/troubleshooting/linkedin-issues
/sheets/stocks/earnings                    /sheets/stocks/stockdata
/sdk/go/options/chain                      /sdk/py/options/chain
```

Same job, same assertion, three destinations, **one of them the same URL**. It was #188 — 57 genuinely deleted pages on staging — and it cleared only when that defect was fixed. A check people have been taught to distrust reports nothing when it is right.

## Wait, not retry

#185 proposed retrying once after 90s. Measured here, the retry-granularity question is nearly moot:

| Suite | Test cases | Runtime | Failed-only retry saves |
|---|---|---|---|
| redirects | 91 | 2.46s | ~2.4s |
| sitemap | **2** | 1.10s | **nothing** — all 258 probes live inside one test |
| e2e | Playwright | ~35s | already `retries: 1` |

The 90s sleep dominates by ~40×. So the real choice is retry vs wait:

- **retry** charges 90s to every *genuine* failure, forever, and automates the "passed second time, must be flake" reflex #185 is about.
- **wait** costs nothing when the site is ready, and only as long as the deploy actually takes when it is not.

It is also cheaper than #185 assumed: option 1 was costed as needing a cross-repo token to poll deploy state. A readiness probe needs no token and no GitHub API.

## Two properties that are easy to get wrong

**It probes cache-busted.** A probe served from a warm edge copy reports the *previous* deployment as ready. During #188 two deleted pages answered 200 from cache for 2.08 days and made three separate counts wrong.

**It never fails the build.** It is a wait, not an assertion — the suites judge and name the URL. On timeout it proceeds and prints what is still down:

```
::warning::[wait-for-deploy] waited 35s, 19 of 19 probe URL(s) still not answering 200 -- running the suite anyway
    404  .../docs/account/troubleshooting/linkedin-issues/
    ...
  if the suite now fails on these same URLs, it is more likely a real
  regression than a deploy race: the wait above already outlasted a normal deploy.
```

That line is the point: it hands over the diagnosis #185 describes as expensive.

## Verified

Ready (returns in 0s) · not ready (waits, warns, exits 0) · no `TEST_ENV` · unknown `TEST_ENV`. 21 unit tests, including that an unknown environment throws rather than silently defaulting to a host, and that no two attempts share a cache-buster.

Probe list is the redirect **destinations**, imported from `redirects.js` so it cannot drift from what the suite asserts.

**No Playwright step is touched**, and the conditional "only when the runner has none" install stays conditional.

---

### Note on Playwright, for `main` specifically

This PR does not touch the browser install. Worth flagging separately though: `main` still installs Chromium **unconditionally** on every e2e run, while `staging` installs it only when the runner has none (`scripts/resolve-chromium.js`, commit 1c20d1a). On a box with limited disk that difference matters, and it is a candidate for its own PR onto `main`.
