### PR TITLE
test(e2e): run against the machine's Chromium, and stop downloading one CI has

### DIFF
--- a/.github/workflows/post-deploy-tests.yml
+++ b/.github/workflows/post-deploy-tests.yml
@@ -47,7 +47,12 @@ jobs:
           TEST_ENV: ${{ github.event.client_payload.environment }}
         run: yarn test:sitemap
 
-      - run: npx playwright install chromium
+      # Safety net only. The suite prefers the browser already on the runner
+      # (see scripts/resolve-chromium.js), so Chromium updates never wait on a
+      # commit here and the runner downloads nothing it already has. This step
+      # covers a runner image that ships without a browser.
+      - name: Install Playwright Chromium, only when the runner has none
+        run: node scripts/resolve-chromium.js || npx playwright install --with-deps chromium
 
       - name: Run e2e tests
         env:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -127,7 +127,12 @@ jobs:
 
       - run: yarn install --frozen-lockfile
 
-      - run: npx playwright install chromium
+      # Safety net only. The suite prefers the browser already on the runner
+      # (see scripts/resolve-chromium.js), so Chromium updates never wait on a
+      # commit here and the runner downloads nothing it already has. This step
+      # covers a runner image that ships without a browser.
+      - name: Install Playwright Chromium, only when the runner has none
+        run: node scripts/resolve-chromium.js || npx playwright install --with-deps chromium
 
       - name: Run e2e tests against staging
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,3 +142,4 @@ completeness.
 - **Sitemap tests**: `TEST_ENV=production yarn test:sitemap` — fetches the deployed sitemap and requires every URL to answer 200. On staging it asserts the opposite: a `noIndex` build must publish no sitemap
 - **Sitemap lint**: `yarn lint:sitemap` — builds with `PROD=true` and fails if the sitemap lists a URL with no page in `build/`
 - **E2E tests**: `TEST_ENV=staging yarn test:e2e` — Playwright tests for Context7 widget rendering
+- **Browser for e2e**: the machine's own Chromium, not a build this repo pins. `scripts/resolve-chromium.js` resolves it (`CHROMIUM_PATH` override → system browser → Playwright's bundled build) and `playwright.config.js` feeds it to `launchOptions`. Do not reintroduce a bare `browserName: 'chromium'` with no `executablePath` — that re-pins the browser to the installed `@playwright/test`. CI installs Playwright's build only when the runner has no browser. See README.md "Which browser the e2e tests run".

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ The official documentation for [Market Data](https://www.marketdata.app/) — co
 
 ## Documentation Sections
 
-| Section | Path | Description |
-|---------|------|-------------|
-| **API** | `/api` | REST API reference — stocks, options, funds, markets, and utilities |
-| **SDKs** | `/sdk` | Client libraries for Go, Python, and PHP |
-| **Sheets Add-On** | `/sheets` | Google Sheets Add-On documentation |
-| **Accounts & Billing** | `/account` | Account management, plans, billing, and entitlements |
+| Section                | Path       | Description                                                         |
+|------------------------|------------|---------------------------------------------------------------------|
+| **API**                | `/api`     | REST API reference — stocks, options, funds, markets, and utilities |
+| **SDKs**               | `/sdk`     | Client libraries for Go, Python, and PHP                            |
+| **Sheets Add-On**      | `/sheets`  | Google Sheets Add-On documentation                                  |
+| **Accounts & Billing** | `/account` | Account management, plans, billing, and entitlements                |
 
 ## Local Development
 
@@ -41,10 +41,10 @@ Browser → Cloudflare DNS → Worker (hostname lookup) → Cloudflare Pages →
 
 ### Environments
 
-| Environment | Hostname | Pages Project | Git Branch |
-|-------------|----------|---------------|------------|
-| Production | `www.marketdata.app` | `www-marketdata-app` | `main` |
-| Staging | `www-staging.marketdata.app` | `www-staging-marketdata-app` | `staging` |
+| Environment | Hostname                     | Pages Project                | Git Branch |
+|-------------|------------------------------|------------------------------|------------|
+| Production  | `www.marketdata.app`         | `www-marketdata-app`         | `main`     |
+| Staging     | `www-staging.marketdata.app` | `www-staging-marketdata-app` | `staging`  |
 
 ### Worker features
 
@@ -85,7 +85,22 @@ cd worker && TEST_ENV=staging yarn test:integration
 
 # E2E tests (Playwright — Context7 widget)
 TEST_ENV=staging yarn test:e2e
+
+# Script tests (option-symbol checker, Chromium resolver)
+yarn test:scripts
 ```
+
+### Which browser the e2e tests run
+
+The e2e suite runs against **whatever Chromium the machine already has** — `/usr/bin/chromium` on Linux, `Chromium.app`/`Google Chrome.app` on macOS — not against a build this repository pins. `scripts/resolve-chromium.js` picks it, and `playwright.config.js` uses that one resolver.
+
+This is deliberate. `browserName: 'chromium'` is an invisible version pin: it resolves to the single revision bundled with the installed `@playwright/test`, so the browser under test only moves when someone bumps a devDependency and re-runs `playwright install`. That would make this repository the gate on every Chromium update. These specs load third-party script into a real page, so they should see the browser our readers run, the day their OS updates it, with no commit here.
+
+- Every run prints the binary it chose (`Chromium: /usr/bin/chromium (system)`). Read that line first when an e2e test fails.
+- Set `CHROMIUM_PATH=/path/to/binary` to force a specific browser.
+- With no system browser found, it falls back to Playwright's bundled build, so a fresh clone still works after `npx playwright install chromium`.
+- CI runs `node scripts/resolve-chromium.js || npx playwright install --with-deps chromium`, so the runner downloads a browser only when it has none.
+- Trade-off: Playwright only guarantees the revision it bundles, so a system browser far ahead of it can drift on CDP behaviour. That is the price of not holding updates back, and it fails loudly rather than silently.
 
 ## Project Structure
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,8 +1,16 @@
 import { defineConfig } from '@playwright/test';
+import { announceChromium, resolveChromium } from './scripts/resolve-chromium.js';
 
 try {
   process.loadEnvFile();
 } catch {}
+
+// The suite runs against the browser this machine already has, not a revision
+// this repo pins through @playwright/test. See scripts/resolve-chromium.js for
+// how the browser is chosen and why. Undefined here means no system browser was
+// found, and Playwright falls back to its own bundled build.
+const CHROMIUM_PATH = resolveChromium();
+announceChromium(CHROMIUM_PATH);
 
 export default defineConfig({
   testDir: './e2e',
@@ -12,6 +20,8 @@ export default defineConfig({
     headless: true,
     screenshot: 'only-on-failure',
     trace: 'on-first-retry',
+    // Inherited by every project below, none of which sets launchOptions itself.
+    ...(CHROMIUM_PATH && { launchOptions: { executablePath: CHROMIUM_PATH } }),
   },
   projects: [
     {

--- a/scripts/__tests__/resolve-chromium.test.js
+++ b/scripts/__tests__/resolve-chromium.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+
+const SCRIPT = path.resolve(__dirname, '..', 'resolve-chromium.js');
+
+/**
+ * Run the resolver as CI runs it. Returns { code, out }.
+ *
+ * CI chains this exit code (`node scripts/resolve-chromium.js || npx playwright
+ * install ...`), so the code is a contract, not a detail.
+ */
+function run(env) {
+  try {
+    const out = execFileSync('node', [SCRIPT], {
+      encoding: 'utf8',
+      env: { ...process.env, ...env },
+    });
+    return { code: 0, out };
+  } catch (e) {
+    return { code: e.status, out: `${e.stdout || ''}${e.stderr || ''}` };
+  }
+}
+
+test('CHROMIUM_PATH wins when it points at an executable', () => {
+  // `node` itself: an executable that exists on every machine running this test.
+  const { code, out } = run({ CHROMIUM_PATH: process.execPath });
+  assert.strictEqual(code, 0);
+  assert.match(out, new RegExp(`Chromium: ${process.execPath} \\(system\\)`));
+});
+
+test('an unusable CHROMIUM_PATH falls back to the bundled build, and says so', () => {
+  const { code, out } = run({ CHROMIUM_PATH: '/nonexistent/chromium' });
+  assert.strictEqual(code, 1, 'exit 1 tells CI to install Playwright’s build');
+  assert.match(out, /bundled with @playwright\/test/);
+});
+
+test('with no override it reports one answer, and the exit code matches it', () => {
+  const { code, out } = run({ CHROMIUM_PATH: '' });
+  if (code === 0) {
+    assert.match(out, /^Chromium: \S.*\(system\)$/m);
+  } else {
+    assert.strictEqual(code, 1);
+    assert.match(out, /bundled with @playwright\/test/);
+  }
+});

--- a/scripts/resolve-chromium.js
+++ b/scripts/resolve-chromium.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * resolve-chromium.js
+ *
+ * Finds the Chromium this machine already has, so nothing in this repo decides
+ * which browser version the e2e suite runs.
+ *
+ * Playwright's `browserName: 'chromium'` is an invisible version pin: it
+ * resolves to the one revision bundled with the installed @playwright/test, so
+ * the browser only moves when someone bumps a devDependency and re-runs
+ * `playwright install`. That makes this repo the gate on every Chromium update.
+ * The e2e specs load real third-party script into a real page, so they should
+ * see the browser our readers actually run, the day their OS updates it, with
+ * no commit here.
+ *
+ * Resolution order:
+ *   1. CHROMIUM_PATH, when set -- an explicit escape hatch for any binary.
+ *   2. The first system browser found on this platform.
+ *   3. undefined -- callers fall back to Playwright's bundled build, so a fresh
+ *      clone still works after `npx playwright install chromium`.
+ *
+ * Usage (CLI, used by CI to skip a download it does not need):
+ *   node scripts/resolve-chromium.js    # print the choice; exit 0 when a system
+ *                                       # browser was found, 1 when none was
+ *
+ * Trade-off, stated plainly: Playwright only guarantees the revision it
+ * bundles, so a system browser far ahead of it can drift on CDP behaviour.
+ * That is the price of not holding updates back, and it fails loudly rather
+ * than silently.
+ */
+
+'use strict';
+
+const { accessSync, constants } = require('node:fs');
+
+const CANDIDATES = {
+  linux: [
+    '/usr/bin/chromium',
+    '/usr/bin/chromium-browser',
+    '/usr/bin/google-chrome',
+    '/usr/bin/google-chrome-stable',
+    '/snap/bin/chromium',
+  ],
+  darwin: [
+    '/Applications/Chromium.app/Contents/MacOS/Chromium',
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+  ],
+  win32: [
+    'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
+    'C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe',
+  ],
+};
+
+/**
+ * @returns {string|undefined} Path to a system Chromium, or undefined to let
+ *   Playwright use its own bundled build.
+ */
+function resolveChromium() {
+  const candidates = process.env.CHROMIUM_PATH
+    ? [process.env.CHROMIUM_PATH]
+    : (CANDIDATES[process.platform] || []);
+
+  for (const candidate of candidates) {
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Not installed here; try the next one.
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Which binary ran matters the moment a test fails, and the whole point of this
+ * module is that the answer changes over time. Say so on every run.
+ *
+ * @param {string|undefined} path Result of {@link resolveChromium}.
+ */
+function announceChromium(path) {
+  console.log(
+    path
+      ? `Chromium: ${path} (system)`
+      : 'Chromium: bundled with @playwright/test (no system browser found)',
+  );
+}
+
+module.exports = { resolveChromium, announceChromium };
+
+if (require.main === module) {
+  const path = resolveChromium();
+  announceChromium(path);
+  process.exit(path ? 0 : 1);
+}


### PR DESCRIPTION
Cherry-picks `1c20d1a` from `staging` onto `main`. Same commit, no Go v2 SDK work.

## Why now

`main` installs Chromium **unconditionally** on every e2e run, in both workflows:

```
- run: npx playwright install chromium
```

`staging` has not done that since 2026-08-26. On a host with limited disk that difference is the whole point — and anyone running `yarn test:e2e` from a `main` checkout gets an error telling them to install a browser, rather than using the one already on the machine.

Measured on the box this was prepared on:

```
disk:              6.9G free of 50G (86% used)
playwright cache:  none — nothing downloaded
system chromium:   /usr/bin/chromium
```

## What it changes

`scripts/resolve-chromium.js` resolves a browser once — `CHROMIUM_PATH` override → first system browser for the platform → `undefined` so callers fall back to Playwright's bundled build. `playwright.config.js` feeds it to `launchOptions.executablePath`, inherited by every project. Both install steps become conditional:

```
- name: Install Playwright Chromium, only when the runner has none
  run: node scripts/resolve-chromium.js || npx playwright install --with-deps chromium
```

## Verified on this branch

```
$ node scripts/resolve-chromium.js
Chromium: /usr/bin/chromium (system)

$ TEST_ENV=production yarn test:e2e
7 passed (14.1s)

playwright cache before: none
playwright cache after:  none      <- nothing was downloaded
```

`yarn test:scripts` 15 passing, including the 3 resolver tests this adds.

## Conflict resolution

One conflict, in `post-deploy-tests.yml`, where this commit replaces the install step and `main` has since gained the sitemap step from #193. Resolved by keeping both: the sitemap step stays, the install becomes conditional.

## Note on ordering

#195 (the #185 readiness gate) also touches `pr-checks.yml` and `post-deploy-tests.yml`. Both are additive and in different places, but whichever merges second may want a rebase.
