### PR TITLE
fix(redirects): revive two dead /docs/ URLs found in 404 logs (#197)

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -38,6 +38,28 @@ const REDIRECTS = [
   { from: "/sdk/go/options/strikes", to: "/sdk/go/options/chain" },
   { from: "/sdk/csharp/options/strikes", to: "/sdk/csharp/options/chain" },
   { from: "/sdk/php/stocks/bulk-candles", to: "/sdk/php/stocks/bulkcandles" },
+
+  // --- #197: two pages that moved years apart and took no redirect with them.
+  //
+  // Both were found by the 404 log store, not by a link checker, because
+  // nothing in this repo links to either one. A link checker only sees the
+  // links we still have; these are links the outside world still has.
+  //
+  // /api/category/universal-parameters was a Docusaurus generated-index
+  // route, conjured by `link: { type: "generated-index" }` in
+  // api/universal-parameters/_category_.json. Commit 5ce4d91 (2026-01-08)
+  // deleted that file and added an index.mdx with `slug: /universal-parameters`
+  // in its place. The page is still there and still good -- it just answers on
+  // a different URL now, and the old one has been dead ever since.
+  //
+  // /api/stocks/bulkquotes was a real endpoint page until commit 0444635
+  // (2025-05-07) deleted it. The endpoint did not go away; it was folded into
+  // stocks/quotes, which takes `?symbols=A,B,C`. The docs already say so --
+  // api/universal-parameters/mode.md links the words "Bulk Stock Quotes"
+  // straight at /api/stocks/quotes -- so this rule only teaches the edge what
+  // the prose already knew.
+  { from: "/api/category/universal-parameters", to: "/api/universal-parameters" },
+  { from: "/api/stocks/bulkquotes", to: "/api/stocks/quotes" },
 ];
 
 module.exports = { REDIRECTS };


### PR DESCRIPTION
Closes #197.

Two `/docs/` URLs answer 404 on production with steady traffic across nearly every day of the 404 store's seven-day window — 157 and 139 hits. Neither is a scanner artifact: the nine other `/docs/` 404s in the same window all landed on 2026-08-21 alone, during a sweep that produced 31,646 distinct 404 URLs in one day.

## What each one was

**`/docs/api/category/universal-parameters`** was a Docusaurus generated-index route, conjured by `link: { type: "generated-index" }` in `api/universal-parameters/_category_.json`. Commit 5ce4d91 (2026-01-08) deleted that file and added an `index.mdx` with `slug: /universal-parameters` in its place. The page is still there and still good — it answers on `/docs/api/universal-parameters/` now, and the old URL has been dead ever since.

**`/docs/api/stocks/bulkquotes`** was a real endpoint page until commit 0444635 (2025-05-07) deleted it. The endpoint did not go away — `api/utilities/status.mdx` still lists `/v1/stocks/bulkquotes/` among the monitored services — but the documentation folded it into `stocks/quotes`, which takes `?symbols=A,B,C`. `api/universal-parameters/mode.md` already links the words "Bulk Stock Quotes" straight at `/api/stocks/quotes`, so the prose had settled the destination long before this rule did.

## Why no link fix accompanies these rules

Nothing in this repo links to either URL. Every `.md`, `.mdx`, `.js` and `.json` under the content and tooling directories was searched; the only `bulkquotes` hits are a live Go SDK page, a JSON response example, two code comments and a spell-check dictionary. There are no `category/` links anywhere.

That is precisely why no gate here could have caught them. A link checker sees the links we still have — these are links the outside world still has: bookmarks, search results, other people's pages. It is the class of dead link only a 404 log finds.

## On the store's `first_seen` caveat

Both rows read 2026-08-21 because that is the oldest day the store holds, and the issue is careful to say so. Git puts real dates on them: seven months and fifteen months dead, not six days.

## Verification, before either rule was written

A redirect to a 404 is worse than the 404 it replaces, because it looks handled. Checked against a local `PROD=true` build:

| Route | In build | |
| --- | --- | --- |
| `/docs/api/universal-parameters/` | present | destination |
| `/docs/api/stocks/quotes/` | present | destination |
| `/docs/api/category/universal-parameters/` | absent | shadows no page |
| `/docs/api/stocks/bulkquotes/` | absent | shadows no page |

Both sources are absent on `origin/staging` too, so neither rule shadows a page if the list is ever cherry-picked across branches — the defect `plugins/redirects-file.js` warns about at line 100, which already bit this repo once with the Go SDK `bulkquotes` page.

## Gates

```
lint:links (STRICT_LINKS=true)   exit 0
lint:sitemap                     258 sitemap URL(s) all resolve to a page in the build
redirects-file                   20 redirect(s) -> 40 rules; none shadow a built page
table alignment                  exit 0
option symbols                   exit 0
lib tests                        41 pass, 0 fail
scripts tests                    0 fail
```

Production was not probed. Per the issue, cache-busted requests against `www.marketdata.app` hit the WordPress origin and produced 17-60 second responses and one 503 on 2026-08-27.

## Not in this PR

The same commit 5ce4d91 also deleted `account/_category_.json`, which also carried `link: { type: "generated-index" }`, label "Accounts & Billing". By the identical mechanism that should have killed `/docs/account/category/accounts-billing`. The build confirms that route is absent today, but absence in a build is not evidence anyone ever linked it, so it gets no rule until the 404 store is queried for it.