### PR TITLE
fix(analytics): stop staging reporting into production GA4; move the PHP SDK redirects off the worker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,15 +21,32 @@
 5. Pages serves the file from its `docs/` directory (built and nested there by CI)
 6. Worker returns the response to the client — path stays the same throughout
 
-### Worker features (`worker/`)
+### Worker features
+
+**The worker lives in `MarketData-App/www-marketdata-app`, not here, and it is
+being retired** (MarketData-App/www-marketdata-app#15). Nothing in this repo
+deploys it. What it still does:
 
 - **Hostname-based routing**: `TARGETS` map in `handler.js` maps each hostname to its Cloudflare Pages deployment
-- **Markdown serving**: Requests with `.md` extension or `Accept: text/markdown` header fetch raw source from GitHub and return cleaned markdown (frontmatter stripped, JSX components converted)
-- **SDK PHP redirect**: `/docs/sdk-php/*` → `marketdataapp.github.io/sdk-php/*` (301)
-- **robots.txt blocking**: Returns 404 for `/docs/robots.txt` to prevent stale cached copies
+- **Markdown serving**: rewrites `Accept: text/markdown` to the twin's path and proxies it. It does NOT fetch source from GitHub — it stopped on 2026-08-25, for reasons recorded in `handler.js`
+- **SDK PHP redirect**: `/docs/sdk-php/*` → `marketdataapp.github.io/sdk-php/*` (301), with a doubled-directory collapse
+- **cdn-cgi rescue**: `/docs/**/cdn-cgi/**` → `/cdn-cgi/**` (302)
 - **Edge caching**: Passes `cf.cacheEverything` on subrequests
 - **404 logging**: Logs pathname and referer for 404 responses
-- Non-docs paths pass through to the origin (WordPress)
+
+What has already moved off it, and needs nothing at the edge:
+
+| Behaviour                           | Now served by                                                     |
+|-------------------------------------|-------------------------------------------------------------------|
+| `Accept: text/markdown` negotiation | a Cloudflare Transform Rule, live on both hostnames               |
+| the legacy `/docs/sdk-php/*` space  | `_redirects`, generated from `SDK_PHP` in `redirects.js`          |
+| `/docs/robots.txt` returning 404    | nothing — the build writes no `robots.txt`, so it 404s on its own |
+| 404 logging                         | Cloudflare zone analytics, which exposes referer on this plan     |
+
+One behaviour dies with the worker and is **accepted, not replaced**: the
+canonical `Link` header on Markdown responses. See
+MarketData-App/www-marketdata-app#16. Pages types `.md` correctly without help,
+so only the header is lost.
 
 ### CI/CD pipeline
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -34,6 +34,38 @@ const config = {
   projectName: "documentation",
 
   headTags: [
+    // The Cloudflare Zaraz loader, and PRODUCTION ONLY.
+    //
+    // Zaraz is configured per ZONE, and www. and www-staging. are both in the
+    // marketdata.app zone. A staging build that loads this fires the same tools
+    // into the same GA4 property as production, and polluted analytics cannot be
+    // un-collected. The gate is therefore the same `PROD` flag that drives
+    // `noIndex` and `url` above, which `deploy-docs.yml` sets only on `main`.
+    //
+    // The tag lives here rather than in `src/theme/Root.js` because the client
+    // bundle cannot read `process.env.PROD`; only this file can. It previously
+    // gated on `NODE_ENV`, which every `yarn build` sets, so staging loaded it.
+    //
+    // The attributes match `ZARAZ_LOADER_ATTRS` in MarketDataApp/website's
+    // `src/lib/site-env.mjs` — the marketing half of the same origin — and each
+    // one is load-bearing:
+    //   data-cfasync="false"     keeps Rocket Loader from deferring the loader
+    //                            past the pageview it exists to record
+    //   referrerpolicy="origin"  sends the origin, not the measured page's path
+    //
+    // Cloudflare answers /cdn-cgi/zaraz/i.js at the edge. No origin serves it.
+    ...(process.env.PROD == "true"
+      ? [
+          {
+            tagName: "script",
+            attributes: {
+              "data-cfasync": "false",
+              src: "/cdn-cgi/zaraz/i.js",
+              referrerpolicy: "origin",
+            },
+          },
+        ]
+      : []),
     {
       tagName: "meta",
       attributes: {

--- a/plugins/redirects-file.js
+++ b/plugins/redirects-file.js
@@ -76,7 +76,7 @@
 
 const { promises: fs } = require('node:fs');
 const path = require('node:path');
-const { REDIRECTS } = require('../redirects');
+const { REDIRECTS, SDK_PHP } = require('../redirects');
 
 /** The URL prefix this site is served under. Matches `baseUrl` in the config. */
 const PREFIX = '/docs';
@@ -147,13 +147,38 @@ module.exports = function redirectsFilePlugin() {
           `${PREFIX}${from}/  ${PREFIX}${to}/  301`,
         ]),
         '',
+        // --- the legacy PHP SDK space, which leaves this site entirely ------
+        //
+        // See the SDK_PHP block in redirects.js for why these exist and why the
+        // doubled prefixes are a closed set rather than a regex.
+        //
+        // THE COLLAPSE RULES MUST COME FIRST. Cloudflare takes the first rule
+        // that matches, so `/docs/sdk-php/*` would swallow every doubled path
+        // and forward the doubling intact if it were emitted above them.
+        '# Legacy PHP SDK docs, now served from GitHub Pages. Generated from the',
+        '# SDK_PHP block in redirects.js. Collapse rules first — Cloudflare takes',
+        '# the first match, so the catch-all below must stay last.',
+        ...SDK_PHP.doubledPrefixes.map(
+          (dir) =>
+            `${PREFIX}${SDK_PHP.source}/${dir}/${dir}/*  ${SDK_PHP.target}/${dir}/:splat  301`
+        ),
+        `${PREFIX}${SDK_PHP.source}/*  ${SDK_PHP.target}/:splat  301`,
+        // The bare form needs its own literal. Cloudflare only normalises a
+        // missing trailing slash when a directory exists at that path, and no
+        // directory is built here — the same defect that took out all 18 bare
+        // redirect sources in #186.
+        `${PREFIX}${SDK_PHP.source}  ${SDK_PHP.target}/  301`,
+        '',
       ];
 
       await fs.writeFile(path.join(outDir, '_redirects'), lines.join('\n'), 'utf8');
 
+      const sdkPhpRules = SDK_PHP.doubledPrefixes.length + 2;
       console.log(
         `[redirects-file] ${REDIRECTS.length} redirect(s) written to _redirects ` +
-          `as ${REDIRECTS.length * 2} rules (bare and slashed); none shadow a built page`
+          `as ${REDIRECTS.length * 2} rules (bare and slashed); none shadow a built page. ` +
+          `Plus ${sdkPhpRules} legacy PHP SDK rules ` +
+          `(${SDK_PHP.doubledPrefixes.length} collapse, 1 catch-all, 1 bare).`
       );
 
       if (REDIRECTS.length === 0) {

--- a/redirects.js
+++ b/redirects.js
@@ -63,4 +63,77 @@ const REDIRECTS = [
   { from: "/api/stocks/bulkquotes", to: "/api/stocks/quotes" },
 ];
 
-module.exports = { REDIRECTS };
+/**
+ * The legacy PHP SDK URL space, which redirects OFF this site entirely.
+ *
+ * These are not route pairs like REDIRECTS above. The source is a prefix under
+ * /docs/sdk-php/ and the target is another host, so they need splats and their
+ * own emitter in plugins/redirects-file.js.
+ *
+ * ---------------------------------------------------------------------------
+ * Why this exists at all
+ * ---------------------------------------------------------------------------
+ *
+ * The PHP SDK documentation moved to /docs/sdk/php/ and nothing in this repo
+ * links to /docs/sdk-php/ any more -- a grep across every .md, .mdx, .js and
+ * .tsx finds zero. This whole space is inbound links the outside world still
+ * holds: old search results, old READMEs, old forum posts.
+ *
+ * It was served by the edge worker until now. The worker is being retired
+ * (MarketData-App/www-marketdata-app#15), and it was the ONLY thing answering
+ * these. Without the rules below every legacy PHP SDK URL becomes a 404.
+ *
+ * ---------------------------------------------------------------------------
+ * The doubled prefixes, and why they are enumerated
+ * ---------------------------------------------------------------------------
+ *
+ * Something in the wild emits doubled directory names -- /sdk-php/classes/
+ * classes/Client rather than /sdk-php/classes/Client. The worker collapsed them
+ * with `subpath.replace(/^(\w+)\/\1\//, '$1/')`, which is logic, and a
+ * _redirects rule cannot run logic.
+ *
+ * It does not need to. The doubled prefix is always a top-level directory of
+ * the generated phpDocumentor site, and that is a CLOSED SET. Measured against
+ * the live site on 2026-08-31:
+ *
+ *   classes namespaces packages indices reports files   all serve pages
+ *   graphs                                              404, does not exist
+ *
+ * So six explicit rules replace the regex, each with a single terminal splat,
+ * which is all Cloudflare Pages _redirects supports. Issue #15 called this
+ * blocked because it read the pattern as needing two wildcards. It does not --
+ * the first wildcard was only ever standing in for this list.
+ *
+ * The collapse is worth keeping rather than dropping. Measured the same day:
+ *
+ *   /sdk-php/classes/MarketDataApp-Client.html          200
+ *   /sdk-php/classes/classes/MarketDataApp-Client.html  404
+ *
+ * ORDER MATTERS. Cloudflare takes the first matching rule, so every collapse
+ * rule must be emitted before the catch-all. plugins/redirects-file.js does
+ * that, and tests/redirects.integration.test.js proves it against the live
+ * site rather than trusting the ordering by eye.
+ */
+const SDK_PHP = {
+  /** Where the generated PHP SDK documentation lives now. No trailing slash. */
+  target: "https://marketdataapp.github.io/sdk-php",
+
+  /** The path this site serves it under. No trailing slash. */
+  source: "/sdk-php",
+
+  /**
+   * Top-level directories of the generated site, each of which shows up
+   * doubled in links the outside world holds. Verified to serve pages; `graphs`
+   * is deliberately absent because that directory does not exist.
+   */
+  doubledPrefixes: [
+    "classes",
+    "namespaces",
+    "packages",
+    "indices",
+    "reports",
+    "files",
+  ],
+};
+
+module.exports = { REDIRECTS, SDK_PHP };

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,17 +1,14 @@
 import React from 'react';
-import Head from '@docusaurus/Head';
 import Context7Widget from '@site/src/components/Context7Widget';
 
-const isProd = process.env.NODE_ENV === 'production';
-
+// The Cloudflare Zaraz loader used to live here, gated on NODE_ENV. Every
+// `yarn build` sets NODE_ENV=production, so staging loaded it too and reported
+// into the production GA4 property. It now sits in `docusaurus.config.js`
+// under `headTags`, gated on PROD — the only place that can read that flag.
+// Do not move it back: the client bundle cannot see `process.env.PROD`.
 export default function Root({children}) {
   return (
     <>
-      {isProd && (
-        <Head>
-          <script data-cfasync="false" src="/cdn-cgi/zaraz/i.js" referrerPolicy="origin" />
-        </Head>
-      )}
       {children}
       <Context7Widget />
     </>

--- a/tests/redirects.integration.test.js
+++ b/tests/redirects.integration.test.js
@@ -44,7 +44,7 @@
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert/strict');
-const { REDIRECTS } = require('../redirects');
+const { REDIRECTS, SDK_PHP } = require('../redirects');
 
 const ALL_ENVIRONMENTS = {
   staging: 'https://www-staging.marketdata.app',
@@ -100,5 +100,73 @@ for (const [env, host] of Object.entries(envs)) {
         assert.equal(res.status, 200, `destination ${to} returned ${res.status}`);
       });
     }
+
+    // --- the legacy PHP SDK space ---------------------------------------
+    //
+    // These left the edge worker and became _redirects rules when the worker
+    // was retired (MarketData-App/www-marketdata-app#15). The worker was the
+    // only thing answering them, so an ordering mistake here does not degrade
+    // a behaviour -- it 404s every inbound link the outside world still holds.
+    //
+    // THE ORDERING IS THE THING UNDER TEST. `/docs/sdk-php/*` matches a
+    // doubled path just as well as a plain one, and Cloudflare takes the first
+    // rule that matches. If the collapse rules ever sort below the catch-all,
+    // every plain URL keeps working and only the doubled ones break -- silent,
+    // and invisible to anyone spot-checking a normal link.
+    describe('legacy PHP SDK', () => {
+      const { source, target, doubledPrefixes } = SDK_PHP;
+
+      for (const dir of doubledPrefixes) {
+        const doubled = `${host}${PREFIX}${source}/${dir}/${dir}/Example.html`;
+        const expected = `${target}/${dir}/Example.html`;
+
+        // Named for what breaks: the doubling must be gone from Location.
+        test(`GET ${dir}/${dir}/ collapses to ${dir}/`, async () => {
+          const res = await fetch(doubled, { redirect: 'manual' });
+          assert.equal(res.status, 301, `${dir} doubled returned ${res.status}`);
+          assert.equal(resolve(res.headers.get('location'), doubled), expected);
+        });
+
+        test(`HEAD ${dir}/${dir}/ collapses to ${dir}/`, async () => {
+          const res = await fetch(doubled, { method: 'HEAD', redirect: 'manual' });
+          assert.equal(res.status, 301, `HEAD ${dir} doubled returned ${res.status}`);
+          assert.equal(resolve(res.headers.get('location'), doubled), expected);
+        });
+
+        // The plain form must survive the collapse rule sitting above it.
+        test(`GET ${dir}/ passes through undoubled`, async () => {
+          const plain = `${host}${PREFIX}${source}/${dir}/Example.html`;
+          const res = await fetch(plain, { redirect: 'manual' });
+          assert.equal(res.status, 301, `${dir} plain returned ${res.status}`);
+          assert.equal(
+            resolve(res.headers.get('location'), plain),
+            `${target}/${dir}/Example.html`
+          );
+        });
+      }
+
+      // Both slash forms of the root, for the reason given at the top of this
+      // file: Cloudflare normalises a bare path only when a directory exists
+      // there, and none is built for this space.
+      for (const [label, url] of [
+        ['bare', `${host}${PREFIX}${source}`],
+        ['slashed', `${host}${PREFIX}${source}/`],
+      ]) {
+        test(`GET root (${label}) -> GitHub Pages`, async () => {
+          const res = await fetch(url, { redirect: 'manual' });
+          assert.equal(res.status, 301, `root ${label} returned ${res.status}`);
+          assert.equal(resolve(res.headers.get('location'), url), `${target}/`);
+        });
+      }
+
+      // A deep path with no doubling, proving the catch-all still carries the
+      // whole remainder rather than truncating at the first segment.
+      test('GET deep path keeps its full subpath', async () => {
+        const deep = `${host}${PREFIX}${source}/a/b/c.html`;
+        const res = await fetch(deep, { redirect: 'manual' });
+        assert.equal(res.status, 301, `deep path returned ${res.status}`);
+        assert.equal(resolve(res.headers.get('location'), deep), `${target}/a/b/c.html`);
+      });
+    });
   });
 }


### PR DESCRIPTION
Three independent changes. Two are prerequisites for retiring the edge worker (MarketData-App/www-marketdata-app#15); one is an analytics bug found on the way.

## 1. Zaraz was loading on staging and reporting into production GA4

The loader was gated on `NODE_ENV === 'production'`, which **every** `yarn build` sets. So it never distinguished the environments. Measured on the live staging site before this change:

```
www-staging.marketdata.app/docs/api/stocks/candles/
  <script data-cfasync="false" src="/cdn-cgi/zaraz/i.js" referrerpolicy="origin">
```

Zaraz is configured per **zone**, and `www.` and `www-staging.` are both in `marketdata.app`. So staging fired the same tools into the same GA4 property — every agent's page load, and every browser check in this repo's lint suites. Polluted analytics cannot be un-collected.

The tag moves to `headTags` because the client bundle cannot read `process.env.PROD`; only `docusaurus.config.js` can. `PROD` is the flag that already drives `noIndex` and `url`, and `deploy-docs.yml` sets it only on `main`.

Verified with two builds:

| Build | Zaraz tag | sitemap | robots |
|---|---|---|---|
| `yarn build` | 0 of 271 pages | absent | `noindex, nofollow` |
| `PROD=true yarn build` | 271 of 271 | written | absent |

Attributes are unchanged and still match `ZARAZ_LOADER_ATTRS` in `MarketDataApp/website`, so both halves of the origin emit one tag.

`pr-checks.yml` sets `PROD: "true"` for the sitemap lint. That build emits the tag, but nothing deploys it.

## 2. The legacy PHP SDK space moves off the worker

The worker is the **only** thing answering `/docs/sdk-php/*` today. Deleting it with nothing in `_redirects` turns every inbound legacy link into a 404. Nothing in this repo links there any more — the PHP docs moved to `/docs/sdk/php/` — so this is entirely links the outside world still holds.

**Issue #15 called this blocked**, reading the pattern as needing two wildcards, which Pages `_redirects` does not support. It does not need two. The worker collapsed doubled directory names with

```js
subpath.replace(/^(\w+)\/\1\//, '$1/')
```

and that first wildcard was only ever standing in for the top-level directories of the generated phpDocumentor site — a **closed set**. Measured 2026-08-31:

```
classes namespaces packages indices reports files   serve pages
graphs                                              404, does not exist
```

So six explicit collapse rules replace the regex, each with one terminal splat. The collapse is worth keeping rather than dropping:

```
/sdk-php/classes/MarketDataApp-Client.html          200
/sdk-php/classes/classes/MarketDataApp-Client.html  404
```

**Order is load-bearing.** Cloudflare's documentation is explicit — "If there are multiple redirects for the same `source` path, the top-most redirect is applied" — so the catch-all is emitted last. Above the collapse rules it would swallow every doubled path and forward the doubling intact. That failure is silent: plain URLs keep working and only doubled ones break, so nobody spot-checking a normal link would see it. The integration test therefore asserts the collapse rather than trusting the order by eye.

Against Cloudflare's documented limits — 2,000 static and 100 dynamic — this adds 7 dynamic and 1 static, and the file shipped 0 dynamic before.

## 3. `CLAUDE.md`'s worker section had drifted

Three bullets were wrong, each verified this session:

- `worker/` is not in this repo; it moved to `MarketData-App/www-marketdata-app`
- markdown serving does **not** fetch source from GitHub — the worker stopped on 2026-08-25 and says so in `handler.js`
- robots.txt blocking is gone; the worker has no robots code left, and the build writes no `robots.txt`, so `/docs/robots.txt` 404s on its own

## Testing

```
TEST_ENV=staging yarn test:redirects    127 pass, 0 fail   (21 new)
yarn test:lib                            68 pass, 0 fail
yarn build / PROD=true yarn build        both green, twins 271 of 271
```

The 21 new assertions pass **today**, against the worker, which still serves this space. They are agnostic to which mechanism answers, so they keep proving the behaviour after the worker goes.

## What this does not do

It does not retire the worker. These rules must be live on **production** first — the worker is still the only thing answering `/docs/sdk-php/*` until they are.
