### PR TITLE
docs(options/chain): document the range, list and operator dte syntax (#189)

### DIFF
--- a/api/options/chain.mdx
+++ b/api/options/chain.mdx
@@ -248,9 +248,22 @@ This is a current chain, so the Greek columns are populated. A historical reques
   Combining the `all` parameter with large options chains such as SPX, SPY, QQQ, etc. can cause you to consume your requests very quickly. The full SPX option chain has more than 20,000 contracts. A request is consumed for each contact you request with a price in the option chain.
   :::
 
-- **dte** `number`
+- **dte** `string`
 
-  Days to expiry. Limit the option chain to a single expiration date closest to the `dte` provided. Should not be used together with `from` and `to`. Take care before combining with `weekly`, `monthly`, `quarterly`, since that will limit the expirations `dte` can return. If you are using the `date` parameter, dte is relative to the `date` provided.
+  Days to expiry, in the same syntax as `strike` and `delta`:
+
+  - Limit the option chain to the single expiration date closest to the `dte` provided. (e.g. `45`)
+  - Limit the option chain to the closest expiration for each of a set of values, deduplicated where two values resolve to the same expiration. (e.g. `15,30,45`)
+  - Limit the option chain to every expiration in a closed interval, both endpoints included. (e.g. `0-45`)
+  - Limit the option chain to every expiration on one side of a bound, using a logical expression. (e.g. `>=30`, `<45`)
+
+  Values are whole numbers of days, at most 36500. A malformed `dte` — a fraction, `nan`, a reversed range, or a value above that cap — is rejected with `400` and a message naming the problem. A well-formed range that matches no expiration returns `s: no_data` rather than an error.
+
+  Should not be used together with `from` and `to`. Take care before combining with `weekly`, `monthly`, `quarterly`, since that will limit the expirations `dte` can return. If you are using the `date` parameter, dte is relative to the `date` provided.
+
+  :::caution A range returns every expiration in it, and bills for all of them
+  A single value and a list each resolve to one expiration per value. A range or an operator does not — it is a filter, so `dte=0-45` on a liquid underlying returns every expiration in that window and consumes one credit per contract returned, exactly like the equivalent `from`/`to` request.
+  :::
 
 - **from** `date`
 


### PR DESCRIPTION
Closes #189 — but **do not merge yet**. See the gate below.

## What changed

The `dte` parameter on `api/options/chain.mdx` now documents the scalar, list,
closed-range and comparison-operator forms, matching the syntax `strike` and
`delta` already accept.

Written from the implementation in `MarketData-App/api#383`, not from the
issue's proposal, so the page describes what actually ships:

- a **scalar** selects the expiration *closest* to reference + N days — the
  long-standing behaviour, unchanged
- a **list** applies that same closest-match per element, deduplicated
- a **range or operator** is a **true filter** — every expiration whose dte
  falls within the bounds, inclusive. That is a different kind of thing from
  the first two, and it is why the cost note exists: `dte=0-45` on a liquid
  underlying bills per contract returned, exactly like the equivalent
  `from`/`to` request.
- whole days only, `nan` rejected, reversed range rejected, capped at 36500.
  That cap is what closes api#306, where an unbounded value escaped as an
  `OverflowError` 500.
- a well-formed range matching no expiration returns `s: no_data`, not an error

The declared type moves from `number` to `string`: the OpenAPI parameter is
`STR`, and neither a list nor a range is a number.

## Why this is a draft

The issue is explicit: open the PR here *"once api#383 is approved/merged, not
before"*. As of this writing api#383 is **open, unapproved (`REVIEW_REQUIRED`),
with a failing test run**.

That gate is not procedural. Measured against production before writing a word:

```
dte=45          203  ok, 1 expiration
dte=15,30,45    400  Bad parameters, please check API documentation.
dte=0-45        400  Bad parameters, please check API documentation.
dte=>=30        400  Bad parameters, please check API documentation.
dte=<45         400  Bad parameters, please check API documentation.
dte=nan         400  Bad parameters, please check API documentation.
dte=99999999    500  Internal server error       <- api#306
```

This page is the public spec. Merging it now would advertise syntax that
answers 400, which is worse than documenting nothing — a reader would follow
the page and conclude the API is broken.

## To land this

1. `MarketData-App/api#383` is approved and merged, and the behaviour is live.
2. Re-run the probes above and confirm the four forms answer `200`/`203`.
3. Mark this ready for review and merge into `staging`.

## Checks

Full suite green on this branch: `lint:seo` (every gated rule passed),
`lint:sitemap`, example parity, highlighting, table alignment, option symbols,
98 script tests, 159 lib tests.
