### PR TITLE
Build sentinel, and the relevance table after the retitles

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -67,6 +67,21 @@ jobs:
           rm -rf build-raw
           cp "build/${BASE_URL}/404.html" build/404.html
 
+      # The last rule is the build sentinel, and it is the reason to read this
+      # step carefully before adding a fourth.
+      #
+      # A CACHED SENTINEL IS WORSE THAN NO SENTINEL: it answers about a previous
+      # deploy while looking authoritative. Hence `no-store`.
+      #
+      # `_headers` is NOT first-match-wins. Every matching rule applies and a
+      # repeated header name APPENDS, so two rules matching build-info.json
+      # would serve two Cache-Control values and `no-store` is not obviously the
+      # winner. None of the three rules above matches it -- `/*.js` requires a
+      # literal `.js` ending, and this is `.json` -- so it stands alone today.
+      # A broad rule added here, or in the website half the orchestrator
+      # concatenates with, would break that. The fix if it ever happens is the
+      # one that repo already worked out for the canonical `Link`: `! Cache-Control`
+      # in the specific rule, unsetting before setting, broad rule first.
       - name: Generate cache headers
         env:
           BASE_URL: ${{ steps.env.outputs.base_url }}
@@ -80,6 +95,9 @@ jobs:
             "" \
             "/${BASE_URL}/*.js" \
             "  Cache-Control: public, max-age=31536000, immutable" \
+            "" \
+            "/${BASE_URL}/build-info.json" \
+            "  Cache-Control: no-store" \
             > build/_headers
 
       # UPLOAD, THEN PRUNE, THEN PROVE IT. Not `aws s3 sync --delete`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,9 +186,20 @@ section name.** `Stock Candles (Python SDK)` matches both words of `stock
 candles`, adjacent and exact; `/api/stocks/candles` is titled `Candles` and
 matches one. The API page loses on `words` and never reaches the tie-break.
 
-That is a content problem, not a ranking one. It is fixed by titling the API
-pages for the concept (`Stock Candles`, not `Candles`), not by any crawler
-setting. Raising `pageRank` further would change nothing.
+That is a content problem, not a ranking one. Nine API pages were retitled for
+their asset class on 2026-09-04 — `Historical Candles` → `Stock Candles` — each
+keeping a `sidebar_label` so the navigation did not move. Four queries flipped.
+
+**Two got worse, and the mechanism is worth knowing before writing a title.**
+`proximity` and the position of a match are both evaluated BEFORE `custom`:
+
+- `bulk candles` — `Bulk Candles (PHP SDK)` holds the two words adjacent.
+  `Bulk Stock Candles` separates them, so the SDK page wins on proximity.
+- `earnings` — `Earnings (Go SDK)` matches at position 0, `Stock Earnings` at
+  position 1.
+
+So a qualifier helps when it adds a word the reader typed, and hurts when it
+lands *between* two words they typed. Raising `pageRank` reaches neither case.
 
 ### Watching it
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,6 +363,62 @@ sees 200s and concludes it works.
 check that reads what the public reads. A green run there proves delivery, not
 completeness.
 
+## The build sentinel
+
+**Which commit is deployed, in one request with an exact answer.**
+
+The orchestrator merges `MarketDataApp/website` and this repo into ONE
+Cloudflare Pages deployment, so "what is live?" is two questions and neither
+source could answer either. The format is agreed with that repo (2026-09-04) so
+both halves answer identically, each under its own prefix so nothing collides
+in the merge:
+
+|                                                   |         |
+|---------------------------------------------------|---------|
+| `https://www.marketdata.app/build-info.json`      | website |
+| `https://www.marketdata.app/docs/build-info.json` | here    |
+
+```json
+{ "source": "documentation", "commit": "<40 hex>", "ref": "main",
+  "environment": "production", "builtAt": "2026-09-04T16:08:31.369Z" }
+```
+
+The sha is **full length** by agreement: an abbreviation is ambiguous across
+two repositories and cannot be handed back to `git`.
+
+Written by `plugins/build-info.js` in postBuild, from `lib/build-info.js`. The
+commit is resolved **once**, in `docusaurus.config.js`, and handed to the
+plugin — two call sites resolving it separately would be two ways to answer one
+question, and they would disagree the day somebody changed one.
+
+### Three traps, each of which defeats the whole thing
+
+**A cached sentinel is worse than none** — it answers about a previous deploy
+while looking authoritative. `deploy-docs.yml` sets `no-store` on it. Remember
+`_headers` is not first-match-wins: every matching rule applies and a repeated
+header name *appends*. None of the three cache rules above it matches
+(`/*.js` needs a literal `.js`, this is `.json`), so it stands alone — but a
+broad rule added here, or in the website half the orchestrator concatenates
+with, would break that.
+
+**A dirty tree must not publish a clean sha.** `git rev-parse HEAD` answers
+happily with uncommitted changes, so a hand-run build would publish a commit
+whose content is not what was built. `dirty: true` appears then, and only then,
+so a deployed sentinel is exactly the five agreed fields.
+
+**The page and the endpoint can legitimately disagree.** Pages are edge-cached
+and the sentinel is not, so the document in front of a reader may come from an
+older build than `/docs/build-info.json` reports. That is two cache states, not
+a defect — and it is precisely the reader `src/clientModules/chunkReload.js`
+exists for. Every page therefore carries `<meta name="build-commit">` with its
+own provenance.
+
+**That tag is the commit and nothing else.** No timestamp, no other
+per-build-varying value: two builds of one tree must differ only where they are
+already known to, or a head-only change cannot be verified by diffing built
+HTML. It was the other repo's condition on the shared format and it is worth as
+much here, where `lib/build-freshness.js` and several checks read built HTML.
+
 ## Markdown Twins
 
 `plugins/markdown-twins.js` writes a Markdown copy of **every** built route into

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,6 +8,19 @@ const darkCodeTheme = require("prism-react-renderer").themes.dracula;
 
 require("dotenv").config();
 
+// Resolved ONCE, here, and handed to plugins/build-info.js. Both halves of the
+// sentinel -- /docs/build-info.json and the <meta name="build-commit"> on every
+// page -- read this one value. Two call sites resolving the commit separately
+// would be two ways to answer one question, and they would disagree the day
+// somebody changed one of them.
+//
+// `builtAt` is in the JSON only. It must never reach the head: two builds of one
+// tree have to differ only where they are already known to, or a head-only
+// change cannot be verified by diffing built HTML. That was the other repo's
+// condition on the shared format and it is worth as much here.
+const { resolveGit } = require("./lib/build-info");
+const BUILD_INFO = { resolved: resolveGit(), builtAt: new Date().toISOString() };
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title:
@@ -143,6 +156,7 @@ const config = {
   ],
 
   plugins: [
+    ['./plugins/build-info', BUILD_INFO],
     './plugins/theme-cookie-sync',
     './plugins/markdown-twins',
     './plugins/not-found-head',

--- a/lib/__tests__/build-info.test.js
+++ b/lib/__tests__/build-info.test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+/**
+ * Self-tests for lib/build-info.js.
+ *
+ * The format is agreed with `MarketData-App/website` so the two halves of one
+ * Cloudflare Pages deployment answer identically. **Most of what is asserted
+ * here is that agreement**, not an internal preference: a field renamed on one
+ * side and not the other gives two sentinels that cannot be compared, which is
+ * the entire point of having them.
+ *
+ * `git` is injected rather than shelled out to, so every case below — CI, a
+ * clean local tree, a dirty one, no git at all — is reachable from a machine
+ * that is only ever in one of those states.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { resolveGit, environmentOf, buildInfo, buildCommitTag } = require('../build-info');
+
+const SHA = '43a17b1f8e51a2ba70c60b4edf49f1f5795543bb';
+
+/** A fake `git` that answers from a table and records what it was asked. */
+function fakeGit(answers) {
+  const asked = [];
+  const run = (args) => {
+    asked.push(args.join(' '));
+    return Object.prototype.hasOwnProperty.call(answers, args[0]) ? answers[args[0]] : null;
+  };
+  run.asked = asked;
+  return run;
+}
+
+// ---------------------------------------------------------------------------
+// resolveGit
+// ---------------------------------------------------------------------------
+
+test('CI is believed, and its tree is never questioned', () => {
+  // GITHUB_SHA is what the workflow was DISPATCHED with, and it is the value
+  // the other half's post-deploy assertion compares against. Reading the tree
+  // instead would answer a subtly different question wherever CI checks out a
+  // merge commit.
+  const run = fakeGit({ 'rev-parse': 'ignored', status: 'M something' });
+  const got = resolveGit({ env: { GITHUB_SHA: SHA, GITHUB_REF_NAME: 'main' }, run });
+  assert.deepEqual(got, { sha: SHA, ref: 'main', dirty: false });
+  assert.deepEqual(run.asked, [], 'CI must not be asked about its working tree');
+});
+
+test('a clean local tree reports the commit and no dirty flag', () => {
+  const run = fakeGit({ 'rev-parse': SHA, status: '' });
+  const got = resolveGit({ env: {}, run });
+  assert.equal(got.sha, SHA);
+  assert.equal(got.dirty, false);
+});
+
+test('a DIRTY local tree is flagged', () => {
+  // The failure this exists to stop: `git rev-parse HEAD` answers happily with
+  // uncommitted changes, so the build would publish a commit whose content is
+  // not what was built -- authoritative and wrong, exactly when somebody
+  // debugging a deploy is trusting it.
+  const run = fakeGit({ 'rev-parse': SHA, status: ' M lib/build-info.js\n' });
+  assert.equal(resolveGit({ env: {}, run }).dirty, true);
+});
+
+test('no git at all is not a build error', () => {
+  const run = fakeGit({});
+  const got = resolveGit({ env: {}, run });
+  assert.equal(got.sha, null);
+  assert.equal(got.ref, null);
+});
+
+// ---------------------------------------------------------------------------
+// environmentOf -- must match docusaurus.config.js exactly
+// ---------------------------------------------------------------------------
+
+test('only PROD=true is production', () => {
+  assert.equal(environmentOf({ PROD: 'true' }), 'production');
+  for (const v of ['false', '1', 'TRUE', '', undefined]) {
+    assert.equal(environmentOf({ PROD: v }), 'staging', `PROD=${v}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// buildInfo -- the agreed document
+// ---------------------------------------------------------------------------
+
+const base = { sha: SHA, ref: 'main', dirty: false, environment: 'production', builtAt: '2026-09-04T16:00:00Z' };
+
+test('a deployed sentinel is exactly the five agreed fields', () => {
+  const doc = buildInfo(base);
+  assert.deepEqual(Object.keys(doc).sort(), ['builtAt', 'commit', 'environment', 'ref', 'source'].sort());
+  assert.equal(doc.source, 'documentation');
+  assert.equal(doc.commit, SHA);
+});
+
+test('the sha is full length, which is half the agreement', () => {
+  // An abbreviation is ambiguous across two repositories and cannot be handed
+  // straight back to git.
+  assert.equal(buildInfo(base).commit.length, 40);
+});
+
+test('dirty appears only when true, so a deployed document is unchanged by it', () => {
+  assert.equal('dirty' in buildInfo(base), false);
+  assert.equal(buildInfo({ ...base, dirty: true }).dirty, true);
+});
+
+test('a missing commit says so rather than omitting the field', () => {
+  // A consumer comparing commits must see a value it can fail on, not an
+  // absent key it might read as "no opinion".
+  const doc = buildInfo({ ...base, sha: null, ref: null });
+  assert.equal(doc.commit, 'unknown');
+  assert.equal(doc.ref, 'unknown');
+});
+
+// ---------------------------------------------------------------------------
+// buildCommitTag -- the per-page half
+// ---------------------------------------------------------------------------
+
+test('the tag carries the commit and nothing else', () => {
+  // No timestamp, and no other per-build-varying value: two builds of one tree
+  // must differ only where they are already known to, or a head-only change
+  // cannot be verified by diffing built HTML. That was the other repo's
+  // condition on the shared format.
+  assert.equal(buildCommitTag(SHA), SHA);
+});
+
+test('anything that is not a full sha produces no tag at all', () => {
+  // Better no provenance than provenance that cannot be fed back to git.
+  for (const v of [null, undefined, '', 'unknown', '43a17b1', `${SHA}X`, SHA.toUpperCase()]) {
+    assert.equal(buildCommitTag(v), null, String(v));
+  }
+});

--- a/lib/algolia-relevance.js
+++ b/lib/algolia-relevance.js
@@ -70,7 +70,7 @@ const RELEVANCE = [
   { q: 'stockdata', want: '/sheets/stocks/stockdata' },
   { q: 'optionchain', want: '/sheets/options/optionchain' },
 
-  // --- Known gaps: the SDK titles embed their section --------------------
+  // --- Known gaps: proximity and position, which pageRank cannot reach ---
   // "Stock Candles (Python SDK)" matches both words of `stock candles`,
   // adjacent and exact. `/api/stocks/candles` is titled "Candles" and matches
   // one, so it loses on `words` and never reaches the tie-break where
@@ -78,11 +78,11 @@ const RELEVANCE = [
   //
   // No crawler setting fixes these. Titling the API pages for the concept
   // does: "Stock Candles" would match fully AND win at pageRank 100 over 30.
-  { q: 'stock candles', want: '/api/stocks/candles', known: 'retitled "Stock Candles" 2026-09-04; awaiting production' },
-  { q: 'option quotes', want: '/api/options/quotes', known: 'retitled "Option Quotes" 2026-09-04; awaiting production' },
-  { q: 'bulk candles', want: '/api/stocks/bulkcandles', known: 'retitled "Bulk Stock Candles" 2026-09-04; awaiting production' },
-  { q: 'earnings', want: '/api/stocks/earnings', known: 'retitled "Stock Earnings" 2026-09-04; awaiting production' },
-  { q: 'option expirations', want: '/api/options/expirations', known: 'retitled "Option Expirations" 2026-09-04; awaiting production' },
+  { q: 'stock candles', want: '/api/stocks/candles' },
+  { q: 'option quotes', want: '/api/options/quotes' },
+  { q: 'bulk candles', want: '/api/stocks/bulkcandles', known: '"Bulk Candles (PHP SDK)" holds the two words adjacent; the retitle put "Stock" between them, and proximity outranks pageRank' },
+  { q: 'earnings', want: '/api/stocks/earnings', known: '"Earnings (Go SDK)" matches at position 0, "Stock Earnings" at position 1, and position outranks pageRank' },
+  { q: 'option expirations', want: '/api/options/expirations' },
 
   // --- Known gaps: a section index loses to its own deep pages -----------
   // Same section, so the same pageRank: this is not a tier problem. Every page
@@ -99,13 +99,13 @@ const RELEVANCE = [
   // order. Demoting Sheets would settle them and cost `optionchain`, which is
   // a worse trade: a reader typing an exact function name should get it.
   { q: 'troubleshooting', want: '/api/troubleshooting', known: 'a bare word with two honest answers; /sheets/troubleshooting is equally right' },
-  { q: 'market status', want: '/api/markets/status', known: 'retitled "Market Status" 2026-09-04; awaiting production' },
+  { q: 'market status', want: '/api/markets/status' },
 
   // --- Known gap that will clear itself ----------------------------------
   // The tag pages were deleted on 2026-09-04 but PRODUCTION still serves them,
   // and production is what the crawler reads. This clears on the first crawl
   // after that removal reaches `main` — at which point the line below must go.
-  { q: 'api credits', want: '/api/rate-limiting', known: 'a deleted tag page production still serves' },
+  { q: 'api credits', want: '/api/rate-limiting', known: 'now returns /api/troubleshooting/running-out-of-credits, which is a defensible answer; the tag page it used to return is gone' },
 ];
 
 /** A URL reduced to a comparable route: no origin, no trailing slash. */

--- a/lib/build-info.js
+++ b/lib/build-info.js
@@ -1,0 +1,124 @@
+'use strict';
+
+/**
+ * Which commit is deployed. One request, one exact answer.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS EXISTS
+ * ---------------------------------------------------------------------------
+ *
+ * The orchestrator merges `MarketDataApp/website` and this repository into ONE
+ * Cloudflare Pages deployment, so "what is live?" is two questions and neither
+ * source could answer either. The only way to tell whether a change had
+ * reached production was to poll a URL and infer from its content -- which
+ * works when you know what changed and fails silently when you do not.
+ *
+ * The failure this makes visible belongs to the other half and is the argument
+ * for both: on 2026-08-28 eight verified-correct pages sat in R2 for hours
+ * because a dispatch payload was malformed, with every local check green
+ * throughout. Nothing inside either source can see that; a sentinel can.
+ *
+ * The format is agreed with `MarketData-App/website` (2026-09-04) so the two
+ * halves answer identically. Each source serves its own file under its own
+ * prefix, so nothing collides in the merge and neither repo needs to know
+ * about the other:
+ *
+ *     https://www.marketdata.app/build-info.json        website
+ *     https://www.marketdata.app/docs/build-info.json   here
+ *
+ * ---------------------------------------------------------------------------
+ * THE SHA IS FULL LENGTH, AND THAT IS PART OF THE AGREEMENT
+ * ---------------------------------------------------------------------------
+ *
+ * An abbreviated sha is ambiguous across two repositories and cannot be handed
+ * straight back to `git`. Forty characters, always.
+ *
+ * ---------------------------------------------------------------------------
+ * A DIRTY TREE MUST NOT PUBLISH A CLEAN SHA
+ * ---------------------------------------------------------------------------
+ *
+ * `git rev-parse HEAD` answers happily with uncommitted changes in the tree,
+ * so a local build would publish a commit whose content is not what was built.
+ * That is this file's own failure mode -- authoritative and wrong -- and it
+ * bites exactly when somebody is debugging a deploy and trusts the answer.
+ *
+ * CI is clean by construction, so `dirty` is absent from every deployed
+ * sentinel. It appears only for a hand-run build, and only when true, which
+ * keeps the deployed document exactly the five agreed fields.
+ */
+
+const { execFileSync } = require('node:child_process');
+
+/** Run a git command, or return null. Never throws: no git is not a build error. */
+function git(args, cwd) {
+  try {
+    return execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Where the commit comes from, in order.
+ *
+ * `GITHUB_SHA` first because it is what the workflow was dispatched WITH, and
+ * that is the value the other half's post-deploy assertion compares against.
+ * Reading the working tree instead would answer a subtly different question in
+ * any CI setup that checks out a merge commit.
+ */
+function resolveGit({ env = process.env, cwd = process.cwd(), run = git } = {}) {
+  const sha = env.GITHUB_SHA || run(['rev-parse', 'HEAD'], cwd);
+  const ref = env.GITHUB_REF_NAME || run(['rev-parse', '--abbrev-ref', 'HEAD'], cwd);
+  // Only ask the tree when CI did not tell us; a CI checkout is clean and the
+  // status call is pure cost there.
+  const dirty = env.GITHUB_SHA ? false : Boolean(run(['status', '--porcelain'], cwd));
+  return { sha, ref, dirty };
+}
+
+/** `production` only when PROD is exactly "true", matching docusaurus.config.js. */
+function environmentOf(env = process.env) {
+  return env.PROD === 'true' ? 'production' : 'staging';
+}
+
+/**
+ * The document, in the agreed shape.
+ *
+ * `builtAt` lives here and NOWHERE ELSE -- see `buildCommitTag`.
+ */
+function buildInfo({ sha, ref, dirty, environment, builtAt }) {
+  const doc = {
+    source: 'documentation',
+    commit: sha || 'unknown',
+    ref: ref || 'unknown',
+    environment,
+    builtAt,
+  };
+  // Present only when true, so a deployed sentinel is exactly the five agreed
+  // fields and a diff between the two halves' output has nothing spurious in it.
+  if (dirty) doc.dirty = true;
+  return doc;
+}
+
+/**
+ * The per-page tag: the commit, and deliberately nothing else.
+ *
+ * **No timestamp, and no other per-build-varying value.** Two builds of one
+ * tree must differ only in places already known to be random, so that a
+ * head-only change can be verified by diffing built HTML directly. A clock in
+ * every `<head>` destroys that for both repositories -- it was
+ * `MarketData-App/website`'s condition on the shared format and it is worth
+ * just as much here, where `lib/build-freshness.js` and several checks read
+ * built HTML.
+ *
+ * It exists because THE PAGE AND THE ENDPOINT CAN LEGITIMATELY DISAGREE. Pages
+ * are edge-cached and the sentinel is not, so the document in front of a
+ * reader may come from an older build than `/docs/build-info.json` reports.
+ * That is two cache states, not a defect -- and it is precisely the reader
+ * `src/clientModules/chunkReload.js` exists for, who is mid-session across a
+ * deploy.
+ */
+function buildCommitTag(sha) {
+  return sha && /^[0-9a-f]{40}$/.test(sha) ? sha : null;
+}
+
+module.exports = { resolveGit, environmentOf, buildInfo, buildCommitTag };

--- a/plugins/build-info.js
+++ b/plugins/build-info.js
@@ -1,0 +1,85 @@
+'use strict';
+
+/**
+ * Writes the build sentinel into the build.
+ *
+ * WHAT it is for and WHY the fields are what they are is in `lib/build-info.js`.
+ * This file is the wiring, and it has two decisions of its own.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY postBuild AND NOT A STATIC FILE
+ * ---------------------------------------------------------------------------
+ *
+ * `static/build-info.json` would be copied verbatim, and its whole value is a
+ * commit nobody can know before the build runs. Committing a placeholder and
+ * rewriting it in CI would mean the file in the repository is always a lie,
+ * and a local build would publish whatever the last person committed.
+ *
+ * ---------------------------------------------------------------------------
+ * WHERE IT LANDS
+ * ---------------------------------------------------------------------------
+ *
+ * `build/build-info.json` here. `deploy-docs.yml` then nests the whole build
+ * under `build/docs/`, so it is served at `/docs/build-info.json` -- the path
+ * agreed with `MarketData-App/website`, whose own sentinel sits at
+ * `/build-info.json`. Neither collides in the orchestrator's merge.
+ *
+ * It is NOT a route, so nothing downstream has to care: `markdown-twins`
+ * requires a twin per route and this is a file, `lint:sitemap` reads the
+ * sitemap, and `lint:seo` walks `index.html`.
+ *
+ * The `no-store` header it needs is in `deploy-docs.yml`, beside the other
+ * cache rules. **A cached sentinel is worse than no sentinel** -- it answers
+ * about a previous deploy while looking authoritative.
+ */
+
+const { promises: fs } = require('node:fs');
+const path = require('node:path');
+const { resolveGit, environmentOf, buildInfo } = require('../lib/build-info');
+
+const FILE = 'build-info.json';
+
+module.exports = function buildInfoPlugin(_context, options = {}) {
+  return {
+    name: 'build-info',
+
+    // The commit also goes into every page's <head>. It is injected here rather
+    // than from docusaurus.config.js so that both halves -- the endpoint and the
+    // tag -- read ONE resolver. Two call sites resolving the commit separately
+    // is two ways to answer the same question, and they would disagree the day
+    // somebody changed one.
+    injectHtmlTags() {
+      const { sha } = options.resolved;
+      const { buildCommitTag } = require('../lib/build-info');
+      const commit = buildCommitTag(sha);
+      if (!commit) return {};
+      return {
+        headTags: [{ tagName: 'meta', attributes: { name: 'build-commit', content: commit } }],
+      };
+    },
+
+    async postBuild({ outDir }) {
+      const { sha, ref, dirty } = options.resolved;
+      const doc = buildInfo({
+        sha,
+        ref,
+        dirty,
+        environment: environmentOf(),
+        builtAt: options.builtAt,
+      });
+
+      const target = path.join(outDir, FILE);
+      const temporary = `${target}.tmp`;
+      await fs.writeFile(temporary, `${JSON.stringify(doc, null, 2)}\n`, 'utf8');
+      await fs.rename(temporary, target);
+
+      // Every value, every build. A sentinel that prints nothing cannot be told
+      // apart from one that wrote `unknown`, and `unknown` is what a build with
+      // no git available produces.
+      console.log(
+        `[build-info] ${FILE}: ${doc.commit} on ${doc.ref} (${doc.environment})` +
+          `${doc.dirty ? ' -- DIRTY TREE, this build is not its commit' : ''}`
+      );
+    },
+  };
+};


### PR DESCRIPTION
Two commits on top of #208.

## `585b92d` — the build sentinel

Serves `https://www.marketdata.app/docs/build-info.json`, saying exactly which commit is deployed.

The orchestrator merges `MarketDataApp/website` and this repo into **one** Cloudflare Pages deployment, so "what is live?" is two questions and neither source could answer either. The format was agreed with that repo **before either side built**, so the two halves answer identically under their own prefixes and neither has to know about the other. Full 40-char sha: an abbreviation is ambiguous across two repositories and cannot be handed back to `git`.

Every page also carries `<meta name="build-commit">`, because pages are edge-cached and the sentinel is not — the document a reader sees may come from an older build than the endpoint reports. That is two cache states, not a defect, and it is the reader `chunkReload.js` exists for.

Three traps, each of which would defeat the whole thing:

- **A cached sentinel is worse than none** — authoritative and stale. `no-store` is set in `deploy-docs.yml`. `_headers` is not first-match-wins and repeated header names *append*, so I verified none of the three existing rules matches it (`/*.js` needs a literal `.js`; this is `.json`) rather than assuming.
- **A dirty tree must not publish a clean sha.** `dirty: true` appears then and only then, so a deployed document is exactly the five agreed fields.
- **No timestamp in the head.** Two builds of one tree must differ only where they are already known to, or a head-only change cannot be verified by diffing built HTML.

`GITHUB_SHA` is preferred over the working tree — it is what the workflow was *dispatched* with, which is what the other repo's post-deploy assertion compares against.

## `43a17b1` — the relevance table after the retitles

Search went 12/20 → 16/20 once the retitles reached production. C2 named four stale `known` lines and they are gone.

**Two rows got worse and the retitles caused it**, recorded with the real mechanism rather than left looking like corpus weight: proximity and match position are both evaluated before `custom`, so putting "Stock" between "Bulk" and "Candles" lost `bulk candles`, and pushing "earnings" off the front of the title lost `earnings`. A qualifier helps when it adds a word the reader typed and hurts when it lands between two words they typed.

## Verification

264 of 264 pages carry the build tag; a simulated CI build emits exactly the five agreed fields with no `dirty`, and the tag matches the endpoint in the same build. `lint:seo`, `lint:sitemap`, 228 lib tests, 103 script tests. The sentinel is a file rather than a route, so it needs no Markdown twin and stays out of the sitemap.