### PR TITLE
Fix the doubled Cache-Control on JS assets

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -69,10 +69,13 @@ jobs:
 
       # THERE WAS A `/${BASE_URL}/*.js` RULE HERE AND IT IS DELETED. 2026-09-04.
       #
-      # It doubled the header it set. `/docs/assets/js/main.<hash>.js` matches
-      # BOTH it and `/docs/assets/*`, and because `_headers` is not
-      # first-match-wins -- every matching rule applies and a repeated header
-      # name APPENDS -- staging served:
+      # It overlapped BOTH of the rules that remain, and the second overlap is
+      # the one worth remembering.
+      #
+      # Against `/docs/assets/*` it doubled a value that agreed with itself:
+      # `/docs/assets/js/main.<hash>.js` matched both, and because `_headers` is
+      # not first-match-wins -- every matching rule applies and a repeated
+      # header name APPENDS -- staging served:
       #
       #   cache-control: public, max-age=31536000, immutable, public, max-age=31536000, immutable
       #
@@ -80,6 +83,12 @@ jobs:
       # never showed it, because the orchestrator's scripts/cache-headers.mjs
       # rewrites Cache-Control there and that rewrite is production-only. So it
       # was invisible from this repository in the environment we look at least.
+      #
+      # Against `/docs/img/*` it overlapped on any `.js` under `/docs/img/`,
+      # where the two values DISAGREED -- a month against an immutable year.
+      # No such file exists, so nothing was ever doubled there; the first one
+      # to appear would have been served both, and which wins is undefined.
+      # Found by `www-marketdata-app` after the deletion had already removed it.
       #
       # DELETED RATHER THAN FIXED WITH `! Cache-Control`, which was the proposed
       # fix and would also have worked. Two reasons it is the weaker one:
@@ -106,12 +115,18 @@ jobs:
       # `_headers` is NOT first-match-wins. Every matching rule applies and a
       # repeated header name APPENDS, so two rules matching build-info.json
       # would serve two Cache-Control values and `no-store` is not obviously the
-      # winner. None of the three rules above matches it -- `/*.js` requires a
-      # literal `.js` ending, and this is `.json` -- so it stands alone today.
+      # winner. Neither rule above it matches: `/assets/*` and `/img/*` are
+      # different prefixes. So it stands alone.
+      #
       # A broad rule added here, or in the website half the orchestrator
       # concatenates with, would break that. The fix if it ever happens is the
       # one that repo already worked out for the canonical `Link`: `! Cache-Control`
-      # in the specific rule, unsetting before setting, broad rule first.
+      # in the specific rule, unsetting before setting, broad rule first --
+      # which is also the shape `www-marketdata-app`'s merge-time gate (#25,
+      # 85e5841) asks for by name. That gate now fails a deploy, in both
+      # environments, when any path would take one header name from two rules.
+      # So a fourth rule that overlaps one of these three is a loud deploy
+      # failure naming both paths, rather than a doubled header nobody sees.
       - name: Generate cache headers
         env:
           BASE_URL: ${{ steps.env.outputs.base_url }}

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -67,8 +67,38 @@ jobs:
           rm -rf build-raw
           cp "build/${BASE_URL}/404.html" build/404.html
 
+      # THERE WAS A `/${BASE_URL}/*.js` RULE HERE AND IT IS DELETED. 2026-09-04.
+      #
+      # It doubled the header it set. `/docs/assets/js/main.<hash>.js` matches
+      # BOTH it and `/docs/assets/*`, and because `_headers` is not
+      # first-match-wins -- every matching rule applies and a repeated header
+      # name APPENDS -- staging served:
+      #
+      #   cache-control: public, max-age=31536000, immutable, public, max-age=31536000, immutable
+      #
+      # Measured by MarketData-App/www-marketdata-app on staging. Production
+      # never showed it, because the orchestrator's scripts/cache-headers.mjs
+      # rewrites Cache-Control there and that rewrite is production-only. So it
+      # was invisible from this repository in the environment we look at least.
+      #
+      # DELETED RATHER THAN FIXED WITH `! Cache-Control`, which was the proposed
+      # fix and would also have worked. Two reasons it is the weaker one:
+      #
+      #   1. The rule matched NOTHING the assets rule did not already cover.
+      #      Every .js in the build is under `assets/js` -- verified, and
+      #      `static/` holds none. An unset-then-set rule would exist only to
+      #      undo and redo what the line above it had just done.
+      #   2. It was a latent hazard, not merely redundant. Assets are safe to
+      #      mark `immutable` for a year because their filenames are
+      #      content-hashed. A file dropped into `static/` is NOT: it would ship
+      #      as `/docs/foo.js`, match this rule, and be pinned in every
+      #      browser's cache for a year with no way to publish a correction.
+      #
+      # So a .js outside `assets/` now inherits the default rather than an
+      # immutable year, which is the safe direction for an unhashed name.
+      #
       # The last rule is the build sentinel, and it is the reason to read this
-      # step carefully before adding a fourth.
+      # step carefully before adding another.
       #
       # A CACHED SENTINEL IS WORSE THAN NO SENTINEL: it answers about a previous
       # deploy while looking authoritative. Hence `no-store`.
@@ -92,9 +122,6 @@ jobs:
             "" \
             "/${BASE_URL}/img/*" \
             "  Cache-Control: public, max-age=2592000" \
-            "" \
-            "/${BASE_URL}/*.js" \
-            "  Cache-Control: public, max-age=31536000, immutable" \
             "" \
             "/${BASE_URL}/build-info.json" \
             "  Cache-Control: no-store" \


### PR DESCRIPTION
One commit. **Do not merge until `MarketData-App/www-marketdata-app`'s orchestrator is green** — production deploys are currently refused for every source (raven's build sentinel set two headers on one path). Merging now would queue a production run that cannot succeed.

## The defect

`/docs/assets/js/main.<hash>.js` matched **both** `/docs/assets/*` and `/docs/*.js`. `_headers` is not first-match-wins — every matching rule applies and a repeated header name *appends* — so staging served:

```
cache-control: public, max-age=31536000, immutable, public, max-age=31536000, immutable
```

Measured by `MarketData-App/www-marketdata-app` on staging. **Production never showed it**, because the orchestrator's `scripts/cache-headers.mjs` rewrites `Cache-Control` there and that rewrite is production-only. So it was live in the one environment we look at least, and invisible from this repository.

The step's own comment already stated this semantics correctly for `build-info.json`. Nobody had carried the reasoning one rule up.

## Deleted rather than unset

`! Cache-Control` on the `/*.js` rule was proposed and would have worked. Deleting is better on two counts:

1. **It covered nothing.** Every `.js` in the build is under `assets/js`, verified across the tree, and `static/` holds none. An unset-then-set rule would exist only to undo and redo the line above it.
2. **It was a latent hazard.** Assets are safe to mark immutable for a year because their filenames are content-hashed. A file dropped into `static/` is not — it would ship as `/docs/foo.js`, match this rule, and be pinned in every browser for a year with no way to publish a correction.

An unhashed `.js` now inherits the default, which is the safe direction.

## Verified on staging

```
cache-control: public, max-age=31536000, immutable      (single)
/docs/build-info.json → cache-control: no-store, cf-cache-status: DYNAMIC
```

The three remaining rules are pairwise disjoint and each sets exactly one header, so this repo contributes no collision to the merged `_headers` — which unblocks the merge-time collision gate in `MarketData-App/www-marketdata-app#24`.