### PR TITLE
docs(sdk-spec): require 402 and 403 as typed errors

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -67,8 +67,15 @@ jobs:
       - name: Check every language tab makes the same request
         run: node scripts/check-example-parity.js
 
+      # BOTH suites, and `lib/` was the one missing. Its 229 tests ran only in
+      # `sync-sdk-docs.yml`, which fires on an SDK export and not on a pull
+      # request -- so the converters, the head rewriters and the build sentinel
+      # were covered by tests that no PR ran. A test that gates nothing is a
+      # test somebody deletes a branch of and never hears about. They cost 0.2s.
       - name: Unit-test the checkers
-        run: node --test scripts/__tests__/*.test.js
+        run: |
+          node --test scripts/__tests__/*.test.js
+          node --test lib/__tests__/*.test.js
 
   broken-links:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -848,9 +848,12 @@ The sha is **full length** by agreement: an abbreviation is ambiguous across
 two repositories and cannot be handed back to `git`.
 
 Written by `plugins/build-info.js` in postBuild, from `lib/build-info.js`. The
-commit is resolved **once**, in `docusaurus.config.js`, and handed to the
-plugin — two call sites resolving it separately would be two ways to answer one
-question, and they would disagree the day somebody changed one.
+commit is resolved **once**, inside the plugin, and both consumers read that one
+value — the endpoint and every page's `<meta name="build-commit">`. Two call
+sites resolving it separately would be two ways to answer one question, and they
+would disagree the day somebody changed one. (It used to be resolved in
+`docusaurus.config.js` and handed over as a plugin option, which published it to
+every reader and rehashed `main.js` on every deploy. See "Diff two builds".)
 
 ### Three traps, each of which defeats the whole thing
 
@@ -879,6 +882,53 @@ per-build-varying value: two builds of one tree must differ only where they are
 already known to, or a head-only change cannot be verified by diffing built
 HTML. It was the other repo's condition on the shared format and it is worth as
 much here, where `lib/build-freshness.js` and several checks read built HTML.
+
+### What gates it, and why each half is somewhere different
+
+A sentinel fails by **answering** — with `unknown`, with a stale commit, or with
+one its own pages disagree with — and an answer is what the reader came for. So
+the failure arrives as confidence, at the moment somebody has stopped guessing.
+Nothing about the page looks different.
+
+**The build asserts itself, in `plugins/build-info.js`'s postBuild.** Not in a
+`scripts/` check: the deploy runs `pnpm run build` and nothing else, so a PR-only
+gate is absent from the one build whose output ships — and the defect is
+introduced by editing that plugin, in a commit that need not touch anything a PR
+check reads. Three states, and only two are honest:
+
+| Resolved commit | The build must then be                               | Verdict                 |
+|-----------------|------------------------------------------------------|-------------------------|
+| a 40-hex sha    | every page carries it, and the endpoint publishes it | the normal case         |
+| none at all     | no page carries a tag, endpoint says `unknown`       | local only, never in CI |
+| anything else   | endpoint answers, every page silent                  | always fatal            |
+
+The third row is the shape worth remembering: `buildCommitTag` refuses to emit a
+value that cannot be handed back to `git`, so a half-valid sha leaves the
+endpoint answering **alone**, with nothing to contradict it. The walk carries a
+floor of 50 pages against a real 265 — a tripwire on the walk, not a baseline on
+the content.
+
+**The wiring is asserted in `scripts/__tests__/deploy-sentinel.test.js`**, which
+reads `deploy-docs.yml` and can fail *before* a workflow runs. Three pairings,
+each with its halves tens of lines apart in a file nobody reads top to bottom:
+
+- the build's `PROD` and the dispatch payload's `environment` come from **one**
+  step, so a production deploy cannot carry a sentinel saying `staging`
+- the payload's `commit_sha` is `github.sha`, the same value `resolveGit()`
+  reads, so the website half's post-deploy comparison compares one question
+  rather than two that happen to agree
+- **exactly one** `_headers` rule matches the sentinel, and it is `no-store`
+
+Each of those is driven by a mutation of the workflow that must break it, and
+`mutate()` fails when its anchor matches nothing — so a mutation that stops
+applying reports itself instead of quietly testing an unchanged file. The
+sentinel's filename is `SENTINEL_FILE` in `lib/build-info.js`, read by both the
+plugin and that test, because renaming it silently unhooks the cache rule.
+
+`lib/__tests__/*.test.js` now runs in PR checks. It did not: 229 tests ran only
+in `sync-sdk-docs.yml`, which fires on an SDK export, so the converters, the
+head rewriters and this sentinel were covered by tests no pull request ran.
+
 
 ## Markdown Twins
 

--- a/account/cancellations.md
+++ b/account/cancellations.md
@@ -1,5 +1,6 @@
 ---
 title: Cancellations
+description: Cancel your Market Data subscription from your member page or the Billing Portal, and see what happens to unused time and how to restart later.
 sidebar_position: 9
 ---
 

--- a/account/data-freshness.md
+++ b/account/data-freshness.md
@@ -1,5 +1,6 @@
 ---
 title: Data Freshness
+description: Real-time, delayed and historical are the three freshness categories Market Data applies to responses, with different cutovers for stocks and options.
 sidebar_position: 5.5
 ---
 

--- a/api/funds/index.mdx
+++ b/api/funds/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Mutual Funds
+description: Root endpoint /v1/funds/ and the mutual fund endpoints that return historical net asset value pricing data for any supported mutual fund symbol.
 slug: /funds
 sidebar_position: 9
 ---

--- a/api/index.md
+++ b/api/index.md
@@ -1,5 +1,9 @@
 ---
-title: Market Data API
+# "Market Data API" alone is the marketing site's <title> for /api/, so the
+# two pages competed for one result -- Bing's Site Scan named the pair on
+# 2026-09-09. The sidebar keeps the short form.
+title: Market Data API Documentation
+sidebar_label: Market Data API
 description: The Market Data API is a REST service with standard HTTP methods and status codes, returning JSON for code or CSV for a spreadsheet.
 sidebar_position: 1
 slug: /

--- a/api/markets/index.mdx
+++ b/api/markets/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Markets
+description: Root endpoint /v1/markets/ and the markets endpoints that return reference data and open or closed status for the markets that Market Data covers.
 slug: /markets
 sidebar_position: 6
 ---

--- a/api/options/quotes.mdx
+++ b/api/options/quotes.mdx
@@ -1,5 +1,6 @@
 ---
 title: Option Quotes
+description: GET /v1/options/quotes/ returns a current or historical end of day quote, with bid, ask and Greeks, for one option contract named by OCC symbol.
 sidebar_label: Quotes
 sidebar_position: 4
 sidebar_custom_props:

--- a/api/stocks/index.mdx
+++ b/api/stocks/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Stocks
+description: Root endpoint /v1/stocks/ and the stock endpoints that return quotes, candles, earnings and other fundamental, technical and pricing data.
 slug: /stocks
 sidebar_position: 7
 ---

--- a/api/stocks/quotes.mdx
+++ b/api/stocks/quotes.mdx
@@ -1,5 +1,6 @@
 ---
 title: Delayed Stock Quotes
+description: GET /v1/stocks/quotes/ returns the most recent delayed quote for one stock, or takes a symbols list to fetch delayed quotes for several in one call.
 sidebar_position: 2
 ---
 

--- a/api/troubleshooting/not-found.mdx
+++ b/api/troubleshooting/not-found.mdx
@@ -1,5 +1,6 @@
 ---
 title: "404: Not Found"
+description: "Diagnose a Market Data API 404 case by case: a market closed on the requested date, an OCC contract that does not exist, or a time with no data."
 sidebar_position: 8
 ---
 

--- a/api/troubleshooting/too-many-concurrent-requests.mdx
+++ b/api/troubleshooting/too-many-concurrent-requests.mdx
@@ -1,5 +1,6 @@
 ---
 title: "429: Too Many Concurrent Requests"
+description: Confirm a 429 comes from the concurrent request limit rather than credits, using the error payload and rate-limit headers, then cut parallel calls.
 sidebar_position: 11
 ---
 

--- a/api/universal-parameters/columns.md
+++ b/api/universal-parameters/columns.md
@@ -1,5 +1,6 @@
 ---
 title: Columns
+description: Use the columns parameter on any Market Data endpoint to return only the fields you name, such as columns=ask,bid, which suppresses the status output.
 sidebar_position: 6
 ---
 

--- a/api/universal-parameters/headers.md
+++ b/api/universal-parameters/headers.md
@@ -1,5 +1,6 @@
 ---
 title: Headers Parameter
+description: Set headers=false on any CSV request to drop the header row and return only the data points; headers are on by default when the parameter is omitted.
 sidebar_label: Headers
 sidebar_position: 7
 ---

--- a/api/universal-parameters/token.md
+++ b/api/universal-parameters/token.md
@@ -1,5 +1,6 @@
 ---
 title: Token
+description: Pass your read-only access token as a token query parameter when a header is impossible, and see why the URL form exposes the token in logs.
 sidebar_position: 0
 ---
 

--- a/docs/SEO.md
+++ b/docs/SEO.md
@@ -85,11 +85,22 @@ Docusaurus derives the description from the page's first paragraph when the
 frontmatter does not set one. That default produced descriptions of every wrong
 shape: a bare heading (`"Problem Overview"`, 16 characters, on eight pages at
 once), and 107 descriptions running past 160 characters to as many as 493.
-Every content page now sets its own `description:` in frontmatter, so nothing
-is derived and nothing repeats.
+**This paragraph used to end "Every content page now sets its own
+`description:` in frontmatter, so nothing is derived."** That was not true:
+the 2026-09-03 pass wrote 165 and left the pages already inside the band on
+the derived text, and on 2026-09-09 Bing's Site Scan flagged 41 of those as
+too short. The derived text is also how a hard-wrapped first line shipped cut
+off at "for an", how an MDX comment shipped as the description of the Go fund
+candles page, and how an admonition's "This formula can only be used with paid
+plans" stood in for the EARNINGS formula. 45 more pages carry a hand-written
+description since that day. Some pages still derive theirs; a derived one that
+is inside the band and unique passes every rule below, and nothing yet asserts
+the frontmatter itself.
 
 *Gated by rule B1 (presence), rule H2 (uniqueness) and rules I2 and I3
-(160 characters or fewer, 70 or more).*
+(160 characters or fewer, 100 or more — the floor was 70 until 2026-09-09,
+when Bing showed it flags anything under 100; see the note beside `DESC_MIN`
+in `scripts/lint-seo.js`).*
 
 ## Canonical URLs
 
@@ -434,7 +445,8 @@ page set a `description:`, so Docusaurus derived one from the first paragraph.
 That is why eight account troubleshooting pages and one Sheets page all
 described themselves as `Problem Overview`, and why 107 descriptions ran past
 160 characters — the longest, `/account/upgrades/`, was 493. 165 pages now
-carry a hand-written description of 70 to 160 characters.
+carry a hand-written description of 70 to 160 characters (210 since
+2026-09-09, when the floor rose to 100).
 
 The six language SDKs document the same endpoints, so a description written
 for the endpoint alone collides the way the titles did. **Every SDK

--- a/lib/__tests__/build-info.test.js
+++ b/lib/__tests__/build-info.test.js
@@ -17,7 +17,14 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
 
-const { resolveGit, environmentOf, buildInfo, buildCommitTag } = require('../build-info');
+const {
+  resolveGit,
+  environmentOf,
+  buildInfo,
+  buildCommitTag,
+  commitTagOf,
+  auditProvenance,
+} = require('../build-info');
 
 const SHA = '43a17b1f8e51a2ba70c60b4edf49f1f5795543bb';
 
@@ -130,4 +137,190 @@ test('anything that is not a full sha produces no tag at all', () => {
   for (const v of [null, undefined, '', 'unknown', '43a17b1', `${SHA}X`, SHA.toUpperCase()]) {
     assert.equal(buildCommitTag(v), null, String(v));
   }
+});
+
+// ---------------------------------------------------------------------------
+// commitTagOf -- reading a built page the only way that survives the minifier
+// ---------------------------------------------------------------------------
+
+test('the tag is read unquoted, single-quoted, quoted and reordered', () => {
+  // This is the whole reason the reader parses instead of matching. `future.v4`
+  // drops the quotes wherever a value does not need them and writes attributes
+  // in whatever order it likes, so a pattern requiring `name="build-commit"`
+  // finds NOTHING on a healthy build. Five instruments across the two
+  // repositories have reported exactly that false zero -- one of them ten
+  // minutes after its author read the warning.
+  const spellings = [
+    `<meta name="build-commit" content="${SHA}">`,
+    `<meta name='build-commit' content='${SHA}'>`,
+    `<meta name=build-commit content=${SHA}>`,
+    `<meta content=${SHA} name=build-commit>`,
+    `<meta NAME=Build-Commit content="${SHA}"/>`,
+  ];
+  for (const tag of spellings) {
+    assert.equal(commitTagOf(`<html><head><title>x</title>${tag}</head><body/></html>`), SHA, tag);
+  }
+});
+
+test('an absent tag and an empty one are different answers', () => {
+  // A page with no provenance and a page claiming none are different defects,
+  // and the second is the stranger one: something wrote the tag with nothing
+  // in it. Collapsing them to `null` would report the second as the first.
+  assert.equal(commitTagOf('<html><head><meta name=robots content=noindex></head></html>'), null);
+  assert.equal(commitTagOf(`<html><head><meta name=build-commit content=""></head></html>`), '');
+});
+
+test('a tag whose name merely starts with build-commit is not the tag', () => {
+  assert.equal(commitTagOf('<html><head><meta name=build-committed content=x></head></html>'), null);
+});
+
+// ---------------------------------------------------------------------------
+// auditProvenance
+// ---------------------------------------------------------------------------
+
+const page = (file, commit) => ({ file, commit });
+
+test('every page naming the expected commit is a clean audit', () => {
+  const got = auditProvenance({ expected: SHA, pages: [page('a.html', SHA), page('b/c.html', SHA)] });
+  assert.deepEqual(got, { scanned: 2, tagged: 2, untagged: [], disagreeing: [] });
+});
+
+test('an untagged page and a disagreeing one are reported apart', () => {
+  const other = SHA.replace(/^4/, '5');
+  const got = auditProvenance({
+    expected: SHA,
+    pages: [page('a.html', SHA), page('b.html', null), page('c.html', other), page('d.html', '')],
+  });
+  assert.deepEqual(got.untagged, ['b.html']);
+  assert.deepEqual(got.disagreeing, [`c.html -> ${other}`, 'd.html -> (empty)']);
+  assert.equal(got.tagged, 3);
+});
+
+test('with no commit resolved, any tag at all is a disagreement', () => {
+  // buildCommitTag emits nothing rather than a value that cannot be handed back
+  // to git, so a tag appearing anyway means a SECOND writer exists.
+  const got = auditProvenance({ expected: null, pages: [page('a.html', null), page('b.html', SHA)] });
+  assert.deepEqual(got.untagged, ['a.html']);
+  assert.deepEqual(got.disagreeing, [`b.html -> ${SHA}`]);
+});
+
+// ---------------------------------------------------------------------------
+// The plugin's postBuild assertion
+// ---------------------------------------------------------------------------
+
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
+
+const buildInfoPlugin = require('../../plugins/build-info');
+const { assertPagesAndSentinelNameOneCommit } = buildInfoPlugin;
+
+/** A build that satisfies everything postBuild asserts, so a test can break one thing. */
+async function fakeBuild({ pages = 60, commit = SHA, spelling = 'quoted' } = {}) {
+  const outDir = await fs.mkdtemp(path.join(os.tmpdir(), 'build-info-'));
+  // assertBundleCarriesNoBuildVaryingValue reads exactly one main.<hash>.js.
+  await fs.mkdir(path.join(outDir, 'assets', 'js'), { recursive: true });
+  await fs.writeFile(path.join(outDir, 'assets', 'js', 'main.abc123.js'), 'console.log(1)\n');
+
+  for (let i = 0; i < pages; i++) {
+    const dir = path.join(outDir, `section${i % 4}`);
+    await fs.mkdir(dir, { recursive: true });
+    const tag =
+      commit === null
+        ? ''
+        : spelling === 'unquoted'
+          ? `<meta content=${commit} name=build-commit>`
+          : `<meta name="build-commit" content="${commit}">`;
+    await fs.writeFile(path.join(dir, `page${i}.html`), `<html><head>${tag}</head><body>x</body></html>`);
+  }
+  return outDir;
+}
+
+const docFor = (sha) => buildInfo({ ...base, sha });
+
+test('postBuild passes when every page names the sentinel commit', async () => {
+  const outDir = await fakeBuild();
+  const got = await assertPagesAndSentinelNameOneCommit(outDir, { sha: SHA, doc: docFor(SHA) });
+  assert.deepEqual(got, { scanned: 60, tagged: 60, expected: SHA });
+});
+
+test('postBuild reads the minified spelling as readily as the quoted one', async () => {
+  const outDir = await fakeBuild({ spelling: 'unquoted' });
+  const got = await assertPagesAndSentinelNameOneCommit(outDir, { sha: SHA, doc: docFor(SHA) });
+  assert.equal(got.tagged, 60);
+});
+
+test('one page without the tag fails the build', async () => {
+  const outDir = await fakeBuild();
+  await fs.writeFile(path.join(outDir, 'section0', 'page0.html'), '<html><head></head><body>x</body></html>');
+  await assert.rejects(
+    () => assertPagesAndSentinelNameOneCommit(outDir, { sha: SHA, doc: docFor(SHA) }),
+    /1 of 60 built page\(s\) carry no build-commit tag/
+  );
+});
+
+test('one page naming a different commit fails the build', async () => {
+  // The refactor this exists for: the endpoint given its own resolver. Both
+  // halves still answer, so nothing else in either repository would notice.
+  const outDir = await fakeBuild();
+  const other = SHA.replace(/^4/, '5');
+  await fs.writeFile(
+    path.join(outDir, 'section0', 'page0.html'),
+    `<html><head><meta name=build-commit content=${other}></head></html>`
+  );
+  await assert.rejects(
+    () => assertPagesAndSentinelNameOneCommit(outDir, { sha: SHA, doc: docFor(SHA) }),
+    /name a commit other than the sentinel's/
+  );
+});
+
+test('a walk that finds almost nothing fails rather than passing', async () => {
+  // A tripwire on the WALK, not a baseline on the content: a renamed output
+  // directory or a truncated build arrives here as a small number, and without
+  // this it arrives as a clean sweep over nothing.
+  const outDir = await fakeBuild({ pages: 3 });
+  await assert.rejects(
+    () => assertPagesAndSentinelNameOneCommit(outDir, { sha: SHA, doc: docFor(SHA) }),
+    /below the floor of 50/
+  );
+});
+
+test('a commit that is not a sha fails, because no page can carry it', async () => {
+  // The endpoint would publish it and every page would stay silent, since
+  // buildCommitTag refuses to emit a value nobody can hand back to git.
+  const outDir = await fakeBuild({ commit: null });
+  await assert.rejects(
+    () => assertPagesAndSentinelNameOneCommit(outDir, { sha: '43a17b1', doc: docFor('43a17b1') }),
+    /is not a 40-character sha/
+  );
+});
+
+test('no commit at all is a local build, and a failure in CI', async () => {
+  const outDir = await fakeBuild({ commit: null });
+  const args = { sha: null, doc: docFor(null) };
+
+  // A workstation without git: the sentinel says `unknown`, no page claims a
+  // commit, and those two agree. That is honest, and it never deploys.
+  const got = await assertPagesAndSentinelNameOneCommit(outDir, { ...args, env: {} });
+  assert.deepEqual(got, { scanned: 60, tagged: 0, expected: null });
+
+  // In CI it cannot happen: Actions always sets GITHUB_SHA and actions/checkout
+  // always leaves a repository behind. A deployed sentinel saying `unknown`
+  // answers every "what is live?" with a shrug.
+  await assert.rejects(
+    () => assertPagesAndSentinelNameOneCommit(outDir, { ...args, env: { CI: 'true' } }),
+    /would ship "unknown"/
+  );
+});
+
+test('a tag with no commit to justify it fails, even locally', async () => {
+  const outDir = await fakeBuild({ commit: null });
+  await fs.writeFile(
+    path.join(outDir, 'section0', 'page0.html'),
+    `<html><head><meta name=build-commit content=${SHA}></head></html>`
+  );
+  await assert.rejects(
+    () => assertPagesAndSentinelNameOneCommit(outDir, { sha: null, doc: docFor(null), env: {} }),
+    /carry a build-commit tag the sentinel does not publish/
+  );
 });

--- a/lib/build-info.js
+++ b/lib/build-info.js
@@ -49,6 +49,24 @@
 
 const { execFileSync } = require('node:child_process');
 
+// The SAME head scanner `lib/noindex-head.js` borrows, and for the same reason:
+// this build writes attributes unquoted and reordered, so a fifth hand-written
+// matcher would be a fifth chance to read a healthy page as a broken one.
+const { voidTags } = require('./not-found-head');
+
+/**
+ * The name both halves of this agree on.
+ *
+ * `plugins/build-info.js` writes it and `.github/workflows/deploy-docs.yml`
+ * gives it `Cache-Control: no-store`. Those two live in different files, in
+ * different languages, and the second is invisible from the first: rename the
+ * file here and the cache rule stops matching, with a sentinel that still
+ * deploys, still answers, and starts answering about a previous build.
+ * `scripts/__tests__/deploy-sentinel.test.js` reads this constant and the
+ * workflow, so the pair cannot drift apart quietly.
+ */
+const SENTINEL_FILE = 'build-info.json';
+
 /** Run a git command, or return null. Never throws: no git is not a build error. */
 function git(args, cwd) {
   try {
@@ -121,4 +139,60 @@ function buildCommitTag(sha) {
   return sha && /^[0-9a-f]{40}$/.test(sha) ? sha : null;
 }
 
-module.exports = { resolveGit, environmentOf, buildInfo, buildCommitTag };
+/**
+ * The commit a built page CLAIMS, read the only way that survives the minifier.
+ *
+ * `future.v4`'s Faster pipeline drops the quotes wherever a value does not need
+ * them, and writes attributes in whatever order it likes:
+ *
+ *     <meta name=build-commit content=a99b8391e31620b55ce53b9b325856d4a4331494>
+ *
+ * A pattern requiring `name="build-commit"` therefore finds NOTHING on a
+ * perfectly healthy build. Five instruments across the two repositories have
+ * been caught by that exact false zero, one of them ten minutes after its
+ * author read the warning -- so this parses rather than matches.
+ *
+ * An absent tag is `null`; a tag with an empty value is `''`. They are
+ * different defects: a page with no provenance, versus a page claiming none.
+ */
+function commitTagOf(html) {
+  const tag = voidTags(html).find((t) => t.name === 'meta' && t.attrs.name?.toLowerCase() === 'build-commit');
+  return tag ? tag.attrs.content ?? '' : null;
+}
+
+/**
+ * Do the pages and the endpoint name ONE commit?
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THIS IS NOT ALREADY TRUE BY CONSTRUCTION
+ * ---------------------------------------------------------------------------
+ *
+ * Today it is: `plugins/build-info.js` resolves the sha once and hands it to
+ * both consumers, which is the property its header exists to protect. This
+ * asserts the property rather than the arrangement that currently produces it.
+ * A refactor that gives the endpoint its own resolver -- the obvious tidy-up,
+ * since each half reads perfectly well alone -- passes every other check in
+ * this repository and produces a page whose provenance disagrees with the
+ * site's. Nobody would look, because both halves would still answer.
+ *
+ * `expected` is `null` when no usable commit exists. Then EVERY tagged page is
+ * a disagreement, which is the right verdict: `buildCommitTag` deliberately
+ * emits no tag rather than one that cannot be handed back to git, so a tag
+ * appearing anyway means a second writer exists.
+ */
+function auditProvenance({ expected, pages }) {
+  const untagged = [];
+  const disagreeing = [];
+  let tagged = 0;
+  for (const { file, commit } of pages) {
+    if (commit === null) {
+      untagged.push(file);
+      continue;
+    }
+    tagged += 1;
+    if (commit !== expected) disagreeing.push(`${file} -> ${commit || '(empty)'}`);
+  }
+  return { scanned: pages.length, tagged, untagged, disagreeing };
+}
+
+module.exports = { SENTINEL_FILE, resolveGit, environmentOf, buildInfo, buildCommitTag, commitTagOf, auditProvenance };

--- a/plugins/build-info.js
+++ b/plugins/build-info.js
@@ -35,9 +35,27 @@
 
 const { promises: fs } = require('node:fs');
 const path = require('node:path');
-const { resolveGit, environmentOf, buildInfo } = require('../lib/build-info');
+const {
+  SENTINEL_FILE,
+  resolveGit,
+  environmentOf,
+  buildInfo,
+  buildCommitTag,
+  commitTagOf,
+  auditProvenance,
+} = require('../lib/build-info');
 
-const FILE = 'build-info.json';
+// Named in lib/build-info.js, because deploy-docs.yml's `no-store` rule names
+// the same string and nothing else couples them.
+const FILE = SENTINEL_FILE;
+
+// A "the walk found nothing" tripwire, NOT a page count to keep in step with
+// the content. The build has 265 pages; a walk that stops matching, a renamed
+// output directory or a truncated build all arrive here as a small number, and
+// without this they arrive as a clean pass over almost nothing. Set far below
+// any plausible content state, so no ordinary edit approaches it. Do not lower
+// it to make it pass. Same shape as scripts/check-highlighting.js's floor.
+const PAGE_FLOOR = 50;
 
 
 /**
@@ -114,6 +132,150 @@ async function assertBundleCarriesNoBuildVaryingValue(outDir) {
   }
 }
 
+/** Every built .html file, depth first. */
+async function builtPages(dir, acc = []) {
+  for (const entry of await fs.readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) await builtPages(full, acc);
+    else if (entry.name.endsWith('.html')) acc.push(full);
+  }
+  return acc;
+}
+
+/** GitHub Actions sets both. Nothing else here should. */
+function inCI(env) {
+  return env.CI === 'true' || env.GITHUB_ACTIONS === 'true';
+}
+
+/**
+ * The pages and the endpoint must name ONE commit, and it must be a real one.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY THE SENTINEL NEEDS A GATE MORE THAN ANYTHING ELSE HERE DOES
+ * ---------------------------------------------------------------------------
+ *
+ * Every other check in this repository guards something that fails VISIBLY. A
+ * sentinel fails by ANSWERING -- with `unknown`, or with a commit its own pages
+ * disagree with -- and an answer is exactly what the reader came for. Its whole
+ * value is that somebody stops guessing what is live and trusts it instead, so
+ * its failure mode is a confident wrong answer at the moment somebody decided
+ * to stop checking. Nothing about the page looks different.
+ *
+ * ---------------------------------------------------------------------------
+ * WHY IT RUNS HERE AND NOT IN A LINT SCRIPT
+ * ---------------------------------------------------------------------------
+ *
+ * The build that deploys runs `pnpm run build` and nothing else. A check in
+ * `scripts/` gates pull requests and is absent from the one build whose output
+ * ships -- and the defect it looks for is introduced by editing THIS file, in a
+ * commit that need not touch anything a PR check reads. So it runs where it
+ * cannot be skipped, beside the bundle property above, for the same reason.
+ *
+ * MarketDataApp/website asserts the same property from `dist/` as
+ * `test:build-sentinel`; that repo builds its own deploy artefact under its own
+ * check suite, so a script is enough there. The two halves must agree about
+ * this or the comparison between them means nothing, which is the whole reason
+ * the format is shared.
+ *
+ * ---------------------------------------------------------------------------
+ * THREE STATES, AND ONLY TWO OF THEM ARE HONEST
+ * ---------------------------------------------------------------------------
+ *
+ *   a real 40-hex sha  -> every page carries it, and the endpoint publishes it
+ *   no commit at all   -> no page carries a tag, and the endpoint says
+ *                         `unknown`. Permitted on a workstation with no git,
+ *                         and never in CI, where GITHUB_SHA is always set.
+ *   anything else      -> the endpoint publishes a string the pages cannot
+ *                         carry. `buildCommitTag` drops it rather than emit a
+ *                         value nobody can hand back to git, so the endpoint
+ *                         answers while every page is silent. Always fatal.
+ */
+async function assertPagesAndSentinelNameOneCommit(outDir, { sha, doc, env = process.env }) {
+  const expected = buildCommitTag(sha);
+
+  if (!expected && sha) {
+    throw new Error(
+      `[build-info] the sentinel would publish commit "${doc.commit}", which is not a 40-character sha.\n\n` +
+        'Every built page therefore carries NO build-commit tag: buildCommitTag()\n' +
+        'emits nothing rather than a value that cannot be handed back to git. So\n' +
+        '/docs/build-info.json would answer, authoritatively, with something no\n' +
+        'reader can use, and no page would contradict it.\n\n' +
+        'GITHUB_SHA is the usual source. It is 40 hex characters or it is a mistake.'
+    );
+  }
+
+  if (!expected && inCI(env)) {
+    throw new Error(
+      '[build-info] no commit could be resolved, so the sentinel would ship "unknown".\n\n' +
+        'resolveGit() falls back rather than throwing, because no git is not a build\n' +
+        'error on a workstation. In CI it is one: Actions always sets GITHUB_SHA and\n' +
+        'actions/checkout always leaves a repository behind. A deployed sentinel\n' +
+        'saying "unknown" answers every "what is live?" with a shrug -- which is the\n' +
+        'answer this endpoint exists to replace.'
+    );
+  }
+
+  const files = await builtPages(outDir);
+  const pages = await Promise.all(
+    files.map(async (file) => ({
+      file: path.relative(outDir, file),
+      commit: commitTagOf(await fs.readFile(file, 'utf8')),
+    }))
+  );
+
+  const { scanned, tagged, untagged, disagreeing } = auditProvenance({ expected, pages });
+
+  if (scanned < PAGE_FLOOR) {
+    throw new Error(
+      `[build-info] only ${scanned} built page(s) under ${outDir}, below the floor of ${PAGE_FLOOR}.\n\n` +
+        'This is a tripwire for a walk that stopped matching, not a content\n' +
+        'baseline. Either the build is incomplete or this check is no longer\n' +
+        'finding what it reads. Do not lower the floor to make it pass.'
+    );
+  }
+
+  const sample = (list) =>
+    list.slice(0, 5).map((p) => `    ${p}`).join('\n') + (list.length > 5 ? `\n    ... and ${list.length - 5} more` : '');
+
+  if (!expected) {
+    if (disagreeing.length) {
+      throw new Error(
+        `[build-info] ${disagreeing.length} of ${scanned} page(s) carry a build-commit tag ` +
+          'the sentinel does not publish.\n' +
+          sample(disagreeing) +
+          '\n\nNo commit was resolved, so this plugin emitted no tag. Something else\n' +
+          'wrote one, which means two writers answer one question.'
+      );
+    }
+    return { scanned, tagged, expected };
+  }
+
+  if (untagged.length) {
+    throw new Error(
+      `[build-info] ${untagged.length} of ${scanned} built page(s) carry no build-commit tag.\n` +
+        sample(untagged) +
+        '\n\ninjectHtmlTags() puts it in every page. A page without it has no\n' +
+        'provenance, so a reader looking at it cannot tell which build served it --\n' +
+        'and the page and the endpoint are ALLOWED to disagree, because pages are\n' +
+        'edge-cached and the sentinel is not. That disagreement is readable only\n' +
+        'while every page states its own commit.'
+    );
+  }
+
+  if (disagreeing.length) {
+    throw new Error(
+      `[build-info] ${disagreeing.length} of ${scanned} page(s) name a commit other than the ` +
+        `sentinel's (${expected}).\n` +
+        sample(disagreeing) +
+        '\n\nThe tag and the endpoint must come from ONE resolver. Two call sites\n' +
+        'answering one question is two ways to be right and one way to disagree,\n' +
+        'and the disagreement is invisible: both halves still answer.'
+    );
+  }
+
+  return { scanned, tagged, expected };
+}
+
 module.exports = function buildInfoPlugin() {
   // ---------------------------------------------------------------------
   // RESOLVED HERE, NOT IN docusaurus.config.js, AND THAT IS THE WHOLE POINT
@@ -179,6 +341,8 @@ module.exports = function buildInfoPlugin() {
       await fs.writeFile(temporary, `${JSON.stringify(doc, null, 2)}\n`, 'utf8');
       await fs.rename(temporary, target);
 
+      const provenance = await assertPagesAndSentinelNameOneCommit(outDir, { sha, doc });
+
       await assertBundleCarriesNoBuildVaryingValue(outDir);
 
       // Every value, every build. A sentinel that prints nothing cannot be told
@@ -186,8 +350,19 @@ module.exports = function buildInfoPlugin() {
       // no git available produces.
       console.log(
         `[build-info] ${FILE}: ${doc.commit} on ${doc.ref} (${doc.environment})` +
-          `${doc.dirty ? ' -- DIRTY TREE, this build is not its commit' : ''}`
+          `${doc.dirty ? ' -- DIRTY TREE, this build is not its commit' : ''}` +
+          `, and all ${provenance.scanned} built page(s) agree` +
+          `${provenance.expected ? '' : ' (no commit resolved, so no page claims one)'}`
       );
     },
   };
 };
+
+// Exported for `lib/__tests__/build-info.test.js`, and for nothing else.
+//
+// Two of the branches above can only be reached with a broken resolver or with
+// no git at all, which is a state a test can describe and a machine cannot be
+// put into on demand. Docusaurus requires this module and calls the default
+// export; a property hung on it is never read, never serialised, and never
+// reaches the client bundle -- unlike a plugin OPTION, which is all three.
+module.exports.assertPagesAndSentinelNameOneCommit = assertPagesAndSentinelNameOneCommit;

--- a/scripts/__tests__/deploy-sentinel.test.js
+++ b/scripts/__tests__/deploy-sentinel.test.js
@@ -1,0 +1,330 @@
+'use strict';
+
+/**
+ * The build sentinel's CI half: the wiring no build can see.
+ *
+ * ---------------------------------------------------------------------------
+ * What this asks that nothing else can
+ * ---------------------------------------------------------------------------
+ *
+ * `plugins/build-info.js` asserts, on every build, that the sentinel it writes
+ * and the pages beside it name one real commit. That is everything a build can
+ * know about itself. Three more things decide whether the DEPLOYED sentinel is
+ * worth reading, and all three live in `deploy-docs.yml`:
+ *
+ *   D1  the build's PROD and the orchestrator's `environment` come from ONE
+ *       step, so a production deploy cannot carry a sentinel saying `staging`
+ *   D2  the dispatch payload's `commit_sha` is the value the build resolved,
+ *       so the post-deploy comparison compares one question
+ *   D3  exactly one `_headers` rule matches the sentinel, and it is `no-store`
+ *
+ * D3 is the one with a history. `_headers` is NOT first-match-wins: every
+ * matching rule applies and a repeated header name APPENDS. A `/docs/*.js` rule
+ * already did exactly that on staging, serving
+ * `cache-control: public, max-age=31536000, immutable, public, max-age=31536000, immutable`,
+ * and it was found by the orchestrator rather than by anything in this
+ * repository. On the sentinel the same overlap is worse than untidy: a cached
+ * sentinel answers about a PREVIOUS deploy while looking exactly as
+ * authoritative as a fresh one, which is strictly worse than having none.
+ *
+ * ---------------------------------------------------------------------------
+ * Why a test rather than care
+ * ---------------------------------------------------------------------------
+ *
+ * Each of these is a pairing whose halves sit tens of lines apart in a file
+ * nobody reads top to bottom, and each half looks ordinary alone. This and
+ * `workflows.test.js` are the only checks here that can fail BEFORE a workflow
+ * runs; everything else about CI is discovered by pushing, and a deploy-time
+ * discovery about the sentinel arrives as a confident wrong answer rather than
+ * as a failure.
+ *
+ * ---------------------------------------------------------------------------
+ * Every check is driven by a mutation, and the mutations verify themselves
+ * ---------------------------------------------------------------------------
+ *
+ * A gate nobody has broken is a gate nobody has tested. Each check below is run
+ * twice: once against the real workflow, where it must pass, and once against a
+ * copy with the defect it exists to catch, where it must fail. `mutate()`
+ * throws when its pattern matches nothing, so a mutation that stops applying --
+ * after any edit to the workflow's wording -- reports itself instead of quietly
+ * testing an unchanged file. Two of the sibling repository's cases were
+ * vacuous until that guard was added.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { SENTINEL_FILE } = require('../../lib/build-info');
+
+const WORKFLOW = path.resolve(__dirname, '../../.github/workflows/deploy-docs.yml');
+const REAL = fs.readFileSync(WORKFLOW, 'utf8');
+
+// ---------------------------------------------------------------------------
+// Reading the workflow
+// ---------------------------------------------------------------------------
+
+/**
+ * The `run:` block of one named step, comments stripped.
+ *
+ * Comments are stripped for the reason `workflows.test.js` records: its first
+ * version matched `cache: pnpm` inside a comment explaining why a job has none,
+ * and reported that job as misconfigured. This workflow holds far more prose
+ * than YAML, and every string looked for below appears in that prose too.
+ */
+function runBlockOf(yml, name) {
+  const start = yml.indexOf(`- name: ${name}`);
+  assert.notEqual(start, -1, `deploy-docs.yml has no step named "${name}"`);
+  const after = yml.slice(start);
+  const runAt = after.indexOf('run: |');
+  assert.notEqual(runAt, -1, `the "${name}" step has no block run:`);
+  const lines = [];
+  for (const line of after.slice(runAt + 'run: |'.length).split('\n').slice(1)) {
+    if (line.trim() === '') continue;
+    if (/^\s{0,9}\S/.test(line)) break; // the next step, at a shallower indent
+    if (/^\s*#/.test(line)) continue;
+    lines.push(line);
+  }
+  return lines.join('\n');
+}
+
+/** `${{ x }}` -> `x`, whitespace flattened, so two spellings compare equal. */
+const expr = (s) => s?.replace(/\$\{\{\s*(.*?)\s*\}\}/g, '$1').replace(/\s+/g, ' ').trim();
+
+/** The generated `_headers`, as [{ pattern, headers }]. */
+function generatedHeaders(yml) {
+  const block = runBlockOf(yml, 'Generate cache headers');
+  assert.match(block, />\s*build\/_headers/, '_headers must still be written to build/_headers');
+
+  const baseUrl = runBlockOf(yml, 'Set environment').match(/echo\s+"base_url=([^"]*)"/)?.[1];
+  assert.equal(baseUrl, 'docs', 'the base path both environments share');
+
+  const args = [...block.matchAll(/"([^"]*)"/g)].map((m) => m[1].replace(/\$\{BASE_URL\}/g, baseUrl));
+  const rules = [];
+  for (const line of args) {
+    if (line.startsWith('/')) rules.push({ pattern: line, headers: [] });
+    else if (line.trim() && rules.length) rules[rules.length - 1].headers.push(line.trim());
+  }
+  // This whole check reads one parse. A printf rewritten in a shape the parse
+  // does not understand must FAIL here, not pass by finding no rules to object
+  // to -- the difference between "nothing was wrong" and "nothing was read".
+  assert.ok(rules.length >= 3, `parsed only ${rules.length} rule(s) out of the printf`);
+  return rules;
+}
+
+/** Cloudflare's `*` splat, which is all these rules use. */
+function matches(pattern, url) {
+  const re = pattern
+    .split('*')
+    .map((part) => part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('.*');
+  return new RegExp(`^${re}$`).test(url);
+}
+
+// ---------------------------------------------------------------------------
+// The checks
+// ---------------------------------------------------------------------------
+
+const CHECKS = {
+  /**
+   * D1. The sentinel's `environment` comes from PROD, which the build reads.
+   * The orchestrator's target comes from the payload. Resolved separately --
+   * two `if` blocks, or a literal on either side -- a production deploy could
+   * carry a sentinel saying `staging` with every check in both repositories
+   * green: the site correct, and only the thing that says WHICH site it is
+   * wrong.
+   */
+  'the build and the dispatch read one env step'(yml) {
+    assert.equal(expr(yml.match(/PROD:\s*(\$\{\{[^}]*\}\})/)?.[1]), 'steps.env.outputs.prod');
+    assert.equal(expr(yml.match(/"environment":\s*"(\$\{\{[^}]*\}\})"/)?.[1]), 'steps.env.outputs.environment');
+  },
+
+  /**
+   * D1, second half. Two outputs of one step is one resolver only while they
+   * agree, and they are written by two separate `echo`s.
+   */
+  'prod and environment are set in the same branch'(yml) {
+    const branches = runBlockOf(yml, 'Set environment').split(/\bthen\b|\belse\b|\bfi\b/);
+    const seen = [];
+    for (const branch of branches) {
+      const outs = Object.fromEntries([...branch.matchAll(/echo\s+"([a-z_]+)=([^"]*)"/g)].map((m) => [m[1], m[2]]));
+      if (!('prod' in outs) && !('environment' in outs)) continue;
+      seen.push(outs);
+      assert.equal(
+        outs.prod === 'true',
+        outs.environment === 'production',
+        `a branch sets prod=${JSON.stringify(outs.prod)} beside environment=${JSON.stringify(outs.environment)}`
+      );
+    }
+    // A parse that matched nothing would satisfy every assertion above it.
+    assert.equal(seen.length, 2, 'expected exactly two branches to set the pair');
+    assert.ok(
+      seen.some((o) => o.environment === 'production') && seen.some((o) => o.environment === 'staging'),
+      'both environments must be reachable'
+    );
+  },
+
+  /**
+   * D2. `resolveGit()` prefers GITHUB_SHA, which is `github.sha`. The
+   * orchestrator is told `commit_sha`, and MarketData-App/website's post-deploy
+   * smoke compares a deployed sentinel against the sha it dispatched. Two
+   * expressions would make that comparison assert that two different questions
+   * happen to have the same answer, which is not a check.
+   */
+  'the dispatch names the commit the build reads'(yml) {
+    const payload = yml.match(/"commit_sha":\s*"(\$\{\{[^}]*\}\})"/)?.[1];
+    assert.ok(payload, 'the dispatch payload no longer sets commit_sha');
+    assert.equal(expr(payload), 'github.sha');
+
+    // GITHUB_SHA set on the Build step would take precedence over the checkout
+    // silently, and the two would disagree with nothing to show it.
+    const build = yml.slice(yml.indexOf('- name: Build'), yml.indexOf('- name: Restructure build output'));
+    assert.doesNotMatch(build, /GITHUB_SHA:/, 'the Build step must not override GITHUB_SHA');
+  },
+
+  /** D3. One claimant, and it is `no-store`. */
+  'one cache rule claims the sentinel, and it is no-store'(yml) {
+    const url = `/docs/${SENTINEL_FILE}`;
+    const claimants = generatedHeaders(yml).filter((r) => matches(r.pattern, url));
+
+    assert.equal(
+      claimants.length,
+      1,
+      `${claimants.length} rule(s) match ${url}: ${claimants.map((r) => r.pattern).join(', ') || 'none'}.\n` +
+        '_headers is NOT first-match-wins -- every matching rule applies and a\n' +
+        'repeated header name APPENDS, so two rules serve two Cache-Control values\n' +
+        'with no rule about which wins. The fix is `! Cache-Control` in the specific\n' +
+        'rule, unsetting before setting, with the broad rule FIRST. That ordering is\n' +
+        'load-bearing: reversed, the file still parses and still deploys.'
+    );
+    assert.deepEqual(
+      claimants[0].headers.map((h) => h.toLowerCase()),
+      ['cache-control: no-store'],
+      'a cached sentinel answers about a previous deploy while looking authoritative'
+    );
+  },
+
+  /**
+   * D3, second half. Rename the sentinel in `lib/build-info.js` and the cache
+   * rule stops matching: the build still succeeds, the endpoint still answers,
+   * and it starts answering about whatever the edge happens to hold.
+   */
+  'the rule names the file the plugin writes'(yml) {
+    assert.ok(
+      generatedHeaders(yml).some((r) => r.pattern === `/docs/${SENTINEL_FILE}`),
+      `deploy-docs.yml has no rule for /docs/${SENTINEL_FILE}`
+    );
+  },
+};
+
+for (const [name, check] of Object.entries(CHECKS)) {
+  test(name, () => check(REAL));
+}
+
+// ---------------------------------------------------------------------------
+// The mutations
+// ---------------------------------------------------------------------------
+
+/** Apply one edit, and fail loudly when it applies to nothing. */
+function mutate(from, to) {
+  const count = REAL.split(from).length - 1;
+  assert.equal(count, 1, `mutation anchor appears ${count} time(s), expected once: ${JSON.stringify(from)}`);
+  return REAL.replace(from, to);
+}
+
+/** The same guard, for an edit that spans lines. */
+function mutateRegex(re, to) {
+  const hits = REAL.match(new RegExp(re, re.flags.includes('g') ? re.flags : `${re.flags}g`)) ?? [];
+  assert.equal(hits.length, 1, `mutation pattern matched ${hits.length} time(s), expected once: ${re}`);
+  return REAL.replace(re, to);
+}
+
+const MUTATIONS = [
+  {
+    what: 'PROD hardcoded instead of read from the env step',
+    yml: () => mutate('PROD: ${{ steps.env.outputs.prod }}', 'PROD: true'),
+    breaks: 'the build and the dispatch read one env step',
+  },
+  {
+    what: 'the dispatch environment hardcoded',
+    yml: () => mutate('"environment": "${{ steps.env.outputs.environment }}"', '"environment": "production"'),
+    breaks: 'the build and the dispatch read one env step',
+  },
+  {
+    what: 'the production branch left saying staging',
+    yml: () => mutate('echo "environment=production"', 'echo "environment=staging"'),
+    breaks: 'prod and environment are set in the same branch',
+  },
+  {
+    what: 'the env step reduced to one branch',
+    yml: () => mutate('echo "prod=true"', 'echo "prod=maybe"'),
+    breaks: 'prod and environment are set in the same branch',
+  },
+  {
+    what: 'the dispatched sha taken from a different expression',
+    yml: () => mutate('"commit_sha": "${{ github.sha }}"', '"commit_sha": "${{ github.event.head_commit.id }}"'),
+    breaks: 'the dispatch names the commit the build reads',
+  },
+  {
+    what: 'GITHUB_SHA overridden on the Build step',
+    yml: () => mutate('          PROD: ${{ steps.env.outputs.prod }}', '          PROD: ${{ steps.env.outputs.prod }}\n          GITHUB_SHA: deadbeef'),
+    breaks: 'the dispatch names the commit the build reads',
+  },
+  {
+    what: 'a broad rule added above, doubling Cache-Control on the sentinel',
+    yml: () =>
+      mutate(
+        '            "/${BASE_URL}/assets/*" \\',
+        '            "/${BASE_URL}/*" \\\n            "  Cache-Control: public, max-age=600" \\\n            "" \\\n            "/${BASE_URL}/assets/*" \\'
+      ),
+    breaks: 'one cache rule claims the sentinel, and it is no-store',
+  },
+  {
+    what: 'the sentinel given a lifetime instead of no-store',
+    yml: () => mutate('"  Cache-Control: no-store"', '"  Cache-Control: public, max-age=60"'),
+    breaks: 'one cache rule claims the sentinel, and it is no-store',
+  },
+  {
+    what: 'the cache rule left naming the old filename',
+    yml: () => mutate('"/${BASE_URL}/build-info.json"', '"/${BASE_URL}/build-info.txt"'),
+    breaks: 'the rule names the file the plugin writes',
+  },
+  {
+    // Not a defect on its own -- a heredoc would generate the same file. The
+    // point is that a shape this parse cannot read must FAIL, rather than find
+    // no rules and report no overlap. "Nothing was wrong" and "nothing was
+    // read" are the same output without the floor.
+    what: 'the printf rewritten in a shape the parse cannot read',
+    yml: () =>
+      mutateRegex(
+        /printf '%s\\n' \\[\s\S]*?> build\/_headers/,
+        "cat > build/_headers <<'EOF'\n/docs/build-info.json\n  Cache-Control: no-store\nEOF"
+      ),
+    breaks: 'one cache rule claims the sentinel, and it is no-store',
+  },
+  {
+    what: 'the generated file written somewhere the deploy does not read',
+    yml: () => mutate('> build/_headers', '> build/cache-headers'),
+    breaks: 'one cache rule claims the sentinel, and it is no-store',
+  },
+  {
+    what: 'the base path changed on one side only',
+    yml: () => mutate('echo "base_url=docs"', 'echo "base_url=documentation"'),
+    breaks: 'one cache rule claims the sentinel, and it is no-store',
+  },
+];
+
+for (const { what, yml, breaks } of MUTATIONS) {
+  test(`fails when ${what}`, () => {
+    assert.throws(() => CHECKS[breaks](yml()), assert.AssertionError, `"${breaks}" passed a broken workflow`);
+  });
+}
+
+test('every check is driven by at least one mutation', () => {
+  // Without this, a check added later is exercised only by the workflow that is
+  // already correct -- which is the state every one of these was written to
+  // leave behind.
+  const covered = new Set(MUTATIONS.map((m) => m.breaks));
+  assert.deepEqual([...Object.keys(CHECKS)].filter((n) => !covered.has(n)), []);
+});

--- a/scripts/lint-seo.js
+++ b/scripts/lint-seo.js
@@ -98,7 +98,7 @@ const ROOT = path.resolve(__dirname, '..');
 
 const TITLE_UNIQUE_ENFORCED = true; // 270 distinct titles across 270 pages
 const DESC_UNIQUE_ENFORCED = true; // 262 distinct descriptions across 262 content pages
-const LENGTH_ENFORCED = true; // 0 titles > 60, and every description is 70-160
+const LENGTH_ENFORCED = true; // 0 titles > 60, and every description is 100-160
 const CARD_IMAGE_ENFORCED = true; // themeConfig.image landed; 271 of 271 declare one
 const HEADING_ORDER_ENFORCED = true; // 0 pages skip a heading level
 // The 404 names no URL of its own: plugins/not-found-head.js cuts the
@@ -134,7 +134,21 @@ const ENFORCED = {
 
 const TITLE_MAX = 60;
 const DESC_MAX = 160;
-const DESC_MIN = 70;
+/**
+ * 70 UNTIL 2026-09-09, AND 70 WAS THE WRONG NUMBER. Bing's Site Scan flagged
+ * 41 pages of this site as "Meta descriptions ... too short", every one of
+ * them green under I3. Of the pages whose description had not changed since
+ * the crawl, every flagged one measured 72 to 97 and every unflagged one 104
+ * or more; the website repo's own pages gave the same bound (82-88 flagged,
+ * 104+ not). So Bing's floor is 100, and a gate below it is a gate that lets
+ * the report through. 48 pages were under it, 45 of them on a description
+ * Docusaurus had DERIVED from the first line of the body -- which is also how
+ * a hard-wrapped sentence shipped cut off at "for an", an MDX comment shipped
+ * as `{/ The DateWindow type is not documented ... /}`, and an admonition's
+ * "This formula can only be used with paid plans" stood in for the page. Each
+ * of those now carries a hand-written `description:`.
+ */
+const DESC_MIN = 100;
 
 const SITE_SUFFIX = 'Market Data';
 

--- a/sdk/csharp/installation.mdx
+++ b/sdk/csharp/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Installation (C# SDK)"
+description: Install the MarketDataApp package from NuGet to use the C# SDK on net8.0 or net10.0, review its dependencies, and update it when a new release ships.
 sidebar_label: Installation
 sidebar_position: 1
 ---

--- a/sdk/csharp/options/expirations.mdx
+++ b/sdk/csharp/options/expirations.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Expirations (C# SDK)"
+description: Call GetExpirationsAsync on the C# SDK Options resource to list expiration dates for an underlying symbol, filtered by strike or historical date.
 sidebar_label: Expirations
 sidebar_position: 2
 ---

--- a/sdk/go/funds/candles.mdx
+++ b/sdk/go/funds/candles.mdx
@@ -1,5 +1,6 @@
 ---
 title: Fund Candles (Go SDK)
+description: Fetch historical daily NAV candles for a mutual fund with the Go SDK Candles and GetCandles methods on the Funds service, with times in US Eastern.
 sidebar_label: Candles
 sidebar_position: 1
 ---

--- a/sdk/go/markets/status-history.mdx
+++ b/sdk/go/markets/status-history.mdx
@@ -1,5 +1,6 @@
 ---
 title: Status History
+description: Call StatusHistory on the Go SDK Markets service to get the open or closed market status for every day in a date range, one entry per day.
 sidebar_position: 2
 ---
 

--- a/sdk/go/options/chain.mdx
+++ b/sdk/go/options/chain.mdx
@@ -1,5 +1,6 @@
 ---
 title: Option Chain (Go SDK)
+description: Fetch a current or historical option chain with the Go SDK Chain method, filtering by expiration, strike, side, moneyness and liquidity.
 sidebar_label: Option Chain
 sidebar_position: 3
 ---

--- a/sdk/go/options/expirations.mdx
+++ b/sdk/go/options/expirations.mdx
@@ -1,5 +1,6 @@
 ---
 title: Expirations (Go SDK)
+description: List the expiration dates with listed option contracts for an underlying using the Go SDK Expirations method, with optional strike and date filters.
 sidebar_label: Expirations
 sidebar_position: 2
 ---

--- a/sdk/go/options/index.mdx
+++ b/sdk/go/options/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Options (Go SDK)
+description: "Go SDK options endpoints: option chains, expiration dates, single and multi-contract quotes, and OCC symbol lookup, each with a context-aware method."
 sidebar_label: Options
 slug: /go/options
 sidebar_position: 11

--- a/sdk/go/options/quotes.mdx
+++ b/sdk/go/options/quotes.mdx
@@ -1,5 +1,6 @@
 ---
 title: Option Quotes (Go SDK)
+description: "Fetch current or historical end-of-day option quotes with the Go SDK: Quote for one OCC contract or Quotes for many, each with a Get wrapper."
 sidebar_label: Option Quotes
 sidebar_position: 4
 ---

--- a/sdk/go/stocks/quotes.mdx
+++ b/sdk/go/stocks/quotes.mdx
@@ -1,5 +1,6 @@
 ---
 title: Stock Quotes (Go SDK)
+description: Fetch real-time quotes for several stock symbols in one call with the Go SDK GetQuotes and Quotes methods on the Stocks service.
 sidebar_label: Quotes
 sidebar_position: 3
 ---

--- a/sdk/go/utilities/api-status.mdx
+++ b/sdk/go/utilities/api-status.mdx
@@ -1,5 +1,6 @@
 ---
 title: API Status (Go SDK)
+description: Check the Market Data API status and its historical uptime with the Go SDK Status and GetStatus methods on the Utilities service, with no parameters.
 sidebar_label: API Status
 sidebar_position: 1
 ---

--- a/sdk/java/installation.mdx
+++ b/sdk/java/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Installation (Java SDK)
+description: Add the marketdata-sdk-java artifact to Gradle or Maven to install the Java SDK on JDK 17 or newer, a single JAR with no third-party HTTP client.
 sidebar_label: Installation
 sidebar_position: 1
 ---

--- a/sdk/java/options/quotes.mdx
+++ b/sdk/java/options/quotes.mdx
@@ -1,5 +1,6 @@
 ---
 title: Option Quotes (Java SDK)
+description: Retrieve bid, ask, last and Greeks for option contracts by OCC symbol with the Java SDK quote and quotes methods, which fan out per symbol.
 sidebar_label: Quotes
 sidebar_position: 4
 ---

--- a/sdk/java/utilities/status.mdx
+++ b/sdk/java/utilities/status.mdx
@@ -1,5 +1,6 @@
 ---
 title: API Status (Java SDK)
+description: Call status() on the Java SDK utilities resource for a public liveness check of Market Data API services, with an online flag and uptime percentiles.
 sidebar_label: Status
 sidebar_position: 1
 ---

--- a/sdk/js/funds/candles.mdx
+++ b/sdk/js/funds/candles.mdx
@@ -1,5 +1,6 @@
 ---
 title: Fund Candles (JavaScript SDK)
+description: Fetch daily OHLC candles for a mutual fund with the JavaScript SDK candles() method on the funds resource, as decoded records, raw JSON or a CSV Blob.
 sidebar_label: Candles
 sidebar_position: 1
 ---

--- a/sdk/js/installation.mdx
+++ b/sdk/js/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Installation (JavaScript SDK)
+description: Install the JavaScript SDK with pnpm, npm or yarn on Node.js 20 or newer, with TypeScript definitions built in and both ESM and CommonJS builds.
 sidebar_label: Installation
 sidebar_position: 1
 ---

--- a/sdk/js/options/expirations.mdx
+++ b/sdk/js/options/expirations.mdx
@@ -1,5 +1,6 @@
 ---
 title: Expirations (JavaScript SDK)
+description: List current or historical option expiration dates for an underlying symbol with the JavaScript SDK expirations() method on the options resource.
 sidebar_label: Expirations
 sidebar_position: 3
 ---

--- a/sdk/js/options/quotes.mdx
+++ b/sdk/js/options/quotes.mdx
@@ -1,5 +1,6 @@
 ---
 title: Option Quotes (JavaScript SDK)
+description: Fetch quotes with full Greeks for one or more option contracts by OCC symbol with the JavaScript SDK quotes() method on the options resource.
 sidebar_label: Quotes
 sidebar_position: 2
 ---

--- a/sdk/js/stocks/candles.mdx
+++ b/sdk/js/stocks/candles.mdx
@@ -1,5 +1,6 @@
 ---
 title: Stock Candles (JavaScript SDK)
+description: Fetch historical OHLCV stock candles with the JavaScript SDK candles() method, which splits long intraday ranges into chunks fetched concurrently.
 sidebar_label: Candles
 sidebar_position: 3
 ---

--- a/sdk/js/stocks/earnings.mdx
+++ b/sdk/js/stocks/earnings.mdx
@@ -1,5 +1,6 @@
 ---
 title: Earnings (JavaScript SDK)
+description: Fetch historical and upcoming earnings for a stock with the JavaScript SDK earnings() method, returned as decoded records, raw JSON or a CSV Blob.
 sidebar_label: Earnings
 sidebar_position: 4
 ---

--- a/sdk/js/stocks/quotes.mdx
+++ b/sdk/js/stocks/quotes.mdx
@@ -1,5 +1,6 @@
 ---
 title: Stock Quotes (JavaScript SDK)
+description: Fetch bid, ask, mid, last and volume for one or more stocks with the JavaScript SDK quotes() method, which returns a MarketDataPromise of records.
 sidebar_label: Quotes
 sidebar_position: 2
 ---

--- a/sdk/php/installation.mdx
+++ b/sdk/php/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Installation (PHP SDK)
+description: Install the PHP SDK with composer require marketdataapp/sdk-php on PHP 8.2 or newer, review its Guzzle and Carbon dependencies, and verify the setup.
 sidebar_label: Installation
 sidebar_position: 2
 ---

--- a/sdk/php/markets/status.mdx
+++ b/sdk/php/markets/status.mdx
@@ -1,5 +1,6 @@
 ---
 title: Market Status (PHP SDK)
+description: Check whether the market was, is or will be open on any trading day with the PHP SDK status() method on the markets resource, as a Statuses object.
 sidebar_label: Market Status
 sidebar_position: 1
 ---

--- a/sdk/php/options/index.mdx
+++ b/sdk/php/options/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Options (PHP SDK)
+description: "PHP SDK options endpoints: option chains, expiration dates, contract quotes and OCC symbol lookup for any underlying, all via the options resource."
 sidebar_label: Options
 slug: /php/options
 sidebar_position: 10

--- a/sdk/php/options/lookup.mdx
+++ b/sdk/php/options/lookup.mdx
@@ -1,5 +1,6 @@
 ---
 title: Lookup (PHP SDK)
+description: Convert a plain-language option description such as AAPL Jan 2025 $180 Call into an OCC symbol with the PHP SDK lookup() method.
 sidebar_label: Lookup
 sidebar_position: 1
 ---

--- a/sdk/php/options/quotes.mdx
+++ b/sdk/php/options/quotes.mdx
@@ -1,5 +1,6 @@
 ---
 title: Option Quotes (PHP SDK)
+description: Fetch current or historical end-of-day quotes for one or more option contracts with the PHP SDK quotes() method on the options resource.
 sidebar_label: Option Quotes
 sidebar_position: 5
 ---

--- a/sdk/php/stocks/candles.mdx
+++ b/sdk/php/stocks/candles.mdx
@@ -1,5 +1,6 @@
 ---
 title: Stock Candles (PHP SDK)
+description: Fetch historical OHLCV candles for a stock with the PHP SDK candles() method, which splits long date ranges into yearly chunks fetched concurrently.
 sidebar_label: Candles
 sidebar_position: 4
 ---

--- a/sdk/php/stocks/prices.mdx
+++ b/sdk/php/stocks/prices.mdx
@@ -1,5 +1,6 @@
 ---
 title: Prices (PHP SDK)
+description: Fetch real-time SmartMid midpoint prices for one or more stocks with the PHP SDK prices() method on the stocks resource, returned as a Prices object.
 sidebar_label: Prices
 sidebar_position: 1
 ---

--- a/sdk/php/stocks/quotes.mdx
+++ b/sdk/php/stocks/quotes.mdx
@@ -1,5 +1,6 @@
 ---
 title: Stock Quotes (PHP SDK)
+description: Fetch real-time quotes for several stocks in one request with the PHP SDK quotes() method on the stocks resource, returned as a Quotes object.
 sidebar_label: Quotes
 sidebar_position: 3
 ---

--- a/sdk/php/utilities/api-status.mdx
+++ b/sdk/php/utilities/api-status.mdx
@@ -1,5 +1,6 @@
 ---
 title: API Status (PHP SDK)
+description: Check Market Data service status and 30 and 90 day uptime with the PHP SDK api_status() method, which caches results and needs no token.
 sidebar_label: API Status
 sidebar_position: 1
 ---

--- a/sdk/php/utilities/headers.mdx
+++ b/sdk/php/utilities/headers.mdx
@@ -1,5 +1,6 @@
 ---
 title: Headers (PHP SDK)
+description: Inspect the request headers your application sends with the PHP SDK headers() method on the utilities resource, to debug Authorization problems.
 sidebar_label: Headers
 sidebar_position: 2
 ---

--- a/sdk/py/installation.mdx
+++ b/sdk/py/installation.mdx
@@ -1,5 +1,6 @@
 ---
 title: Installation (Python SDK)
+description: Install the Python SDK from PyPI with pip or uv on Python 3.10 or newer, with optional pandas or other DataFrame extras for DataFrame output format.
 sidebar_label: Installation
 sidebar_position: 1
 ---

--- a/sheets/index.md
+++ b/sheets/index.md
@@ -1,5 +1,9 @@
 ---
-title: Google Sheets Add-on
+# "Google Sheets Add-on" alone is the marketing site's <title> for /sheets/,
+# so the two pages competed for one result -- Bing's Site Scan named the pair
+# on 2026-09-09. The sidebar keeps the short form.
+title: Google Sheets Add-on Documentation
+sidebar_label: Google Sheets Add-on
 description: The Market Data add-on brings stock, option, index and fund data into Google Sheets through custom formulas. Start here to install and use it.
 sidebar_position: 1
 slug: /

--- a/sheets/stocks/earnings.md
+++ b/sheets/stocks/earnings.md
@@ -1,5 +1,6 @@
 ---
 title: EARNINGS
+description: Use the EARNINGS formula in Google Sheets to fetch current or past earnings data for a stock ticker, with attributes such as eps and report date.
 sidebar_position: 2
 sidebar_custom_props:
   badge: p

--- a/sheets/universal-attributes/no-headers.md
+++ b/sheets/universal-attributes/no-headers.md
@@ -1,5 +1,6 @@
 ---
 title: No Headers
+description: Add the noheaders attribute to any Market Data Google Sheets formula, such as STOCKQUOTE or OPTIONDATA, to leave the header row out of the output.
 sidebar_position: 1
 ---
 


### PR DESCRIPTION
Promotes `staging` to production. Verified live at https://www-staging.marketdata.app/docs/ on build-info commit `58a0b1f`.

## The change in this PR

`internal/sdk-requirements.md` now requires 402 and 403.

The spec was behind its own implementations. §6.1 listed seven error types and §9.1 eight status codes, and neither named 402 or 403 — while `sdk-go`, `sdk-js` and `sdk-csharp` already handle 402, documented publicly at `sdk/go/errors.mdx` and `sdk/js/client.mdx`. `sdk-py` additionally implements `ForbiddenError` for 403. Three of six SDKs got 402 right by accident rather than by requirement; `sdk-py`, `sdk-php` and `sdk-java` have no 402 class at all, and in `sdk-py` a 402 falls through to the generic `MarketdataHttpError`, so the caller must read `.status_code` — the exact thing the taxonomy exists to prevent. The maintainer will open issues against the three once this lands.

- **§6.1** gains `PaymentRequiredError` and `ForbiddenError` in numeric order, with the reasoning for keeping 402 separate: a 402 means the token is valid and the request well-formed, and only the plan does not cover it. That is a different fact from 401 and from 403.
- **§9.1** gains both codes as terminal rows, plus a note on what terminal means for each — the SDK auto-retries neither, but a 402 stands until the plan changes while a 403 can clear on its own (the multi-IP block lifts after about 5 minutes).
- **The "Note on 402"** sits directly under the existing "Note on 404", because that is where the hazard is. That note tells SDKs to return `no_data = true` rather than throw, and it sat four rows above where 402 belongs. Rendering a 402 as no-data asserts the data does not exist, which is false, and it fails silently. No SDK does this today, so the note guards a future regression rather than a live bug.

## Also riding along

Two commits already verified on staging:

- `88ab62c` feat(seo): raise the description floor to 100, and write the 45 that were under it
- `b6613c9` test(sentinel): prove the build can say which commit it is

## Verification

- `pnpm run lint:links` (strict build, broken links and anchors throw) passes, so the `/api/troubleshooting/payment-required/` cross-reference resolves from the internal docs instance.
- Staging deploy green: build/upload run 34840744930, orchestrator run 34840911968 reporting `(environment: staging)`, `Nothing spliced`, 1 sitemap.
- Staging post-deploy suite green: run 34841041236.
- Cache-busted probe of `/docs/internal/sdk-requirements/index.md` on staging serves the new text.

The only CI difference between the branches is `.github/workflows/pr-checks.yml`; `post-deploy-tests.yml` is identical, so the usual one-red-post-deploy-run trap does not apply here.